### PR TITLE
feat: support authentication flow binding overrides by alias

### DIFF
--- a/docs/src/crds/keycloakclient.md
+++ b/docs/src/crds/keycloakclient.md
@@ -220,6 +220,49 @@ data:
   client-secret: c2VjcmV0...   # base64 encoded
 ```
 
+## Authentication Flow Binding Overrides
+
+Keycloak allows overriding the default authentication flows (browser, direct grant) per client via `authenticationFlowBindingOverrides`. Normally this requires the internal UUID of the flow, which is generated dynamically and differs across environments -- making it incompatible with GitOps.
+
+The operator supports **alias-based references** so you can use the human-readable flow alias instead:
+
+| Alias Key | Resolves To | Description |
+|-----------|-------------|-------------|
+| `browserFlowAlias` | `browser` | Browser authentication flow |
+| `directGrantFlowAlias` | `direct_grant` | Direct grant (Resource Owner Password) flow |
+
+The operator resolves aliases to UUIDs at reconciliation time. If both an alias key and the corresponding UUID key are present, the alias takes precedence.
+
+### Example: Using flow aliases
+
+```yaml
+apiVersion: keycloak.hostzero.com/v1beta1
+kind: KeycloakClient
+metadata:
+  name: my-app
+spec:
+  realmRef:
+    name: my-realm
+  definition:
+    clientId: my-app
+    enabled: true
+    publicClient: true
+    standardFlowEnabled: true
+    authenticationFlowBindingOverrides:
+      browserFlowAlias: "my-custom-browser-flow"
+      directGrantFlowAlias: "my-custom-direct-grant"
+```
+
+### Example: Using UUIDs (unchanged, still supported)
+
+```yaml
+    authenticationFlowBindingOverrides:
+      browser: "a3f5c2d1-1234-5678-90ab-abcdef123456"
+      direct_grant: "b4e6d3a2-2345-6789-01bc-bcdef2345678"
+```
+
+If the specified alias does not match any authentication flow in the realm, the operator reports a `FlowAliasResolutionFailed` status with a descriptive error message.
+
 ## Definition Properties
 
 Common properties from [Keycloak ClientRepresentation](https://www.keycloak.org/docs-api/latest/rest-api/index.html#ClientRepresentation):

--- a/internal/controller/keycloak_config.go
+++ b/internal/controller/keycloak_config.go
@@ -225,3 +225,80 @@ func setFieldInDefinition(definition json.RawMessage, field string, value interf
 
 	return result
 }
+
+// flowAliasToKey maps alias-based keys in authenticationFlowBindingOverrides
+// to their corresponding Keycloak API keys.
+var flowAliasToKey = map[string]string{
+	"browserFlowAlias":     "browser",
+	"directGrantFlowAlias": "direct_grant",
+}
+
+// flowLookupFunc resolves a flow alias to its UUID.
+type flowLookupFunc func(ctx context.Context, realmName, alias string) (string, error)
+
+// resolveFlowBindingAliases inspects the definition JSON for
+// authenticationFlowBindingOverrides entries that use alias-based keys
+// (e.g. browserFlowAlias, directGrantFlowAlias) and resolves them to
+// the corresponding Keycloak flow UUIDs via the Admin API.
+// UUID-based keys are left untouched. If both an alias key and the
+// corresponding UUID key are present, the alias takes precedence.
+func resolveFlowBindingAliases(ctx context.Context, kc *keycloak.Client, realmName string, definition json.RawMessage) (json.RawMessage, error) {
+	return resolveFlowBindingAliasesWithLookup(ctx, realmName, definition, func(ctx context.Context, realm, alias string) (string, error) {
+		flow, err := kc.GetAuthenticationFlowByAlias(ctx, realm, alias)
+		if err != nil {
+			return "", err
+		}
+		return flow.ID, nil
+	})
+}
+
+// resolveFlowBindingAliasesWithLookup is the testable core of alias resolution.
+func resolveFlowBindingAliasesWithLookup(ctx context.Context, realmName string, definition json.RawMessage, lookup flowLookupFunc) (json.RawMessage, error) {
+	var defMap map[string]interface{}
+	if err := json.Unmarshal(definition, &defMap); err != nil {
+		return definition, nil
+	}
+
+	overridesRaw, ok := defMap["authenticationFlowBindingOverrides"]
+	if !ok {
+		return definition, nil
+	}
+
+	overrides, ok := overridesRaw.(map[string]interface{})
+	if !ok {
+		return definition, nil
+	}
+
+	changed := false
+	for aliasKey, targetKey := range flowAliasToKey {
+		aliasVal, exists := overrides[aliasKey]
+		if !exists {
+			continue
+		}
+
+		alias, ok := aliasVal.(string)
+		if !ok || alias == "" {
+			return nil, fmt.Errorf("authenticationFlowBindingOverrides.%s must be a non-empty string", aliasKey)
+		}
+
+		flowID, err := lookup(ctx, realmName, alias)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve %s %q: %w", aliasKey, alias, err)
+		}
+
+		overrides[targetKey] = flowID
+		delete(overrides, aliasKey)
+		changed = true
+	}
+
+	if !changed {
+		return definition, nil
+	}
+
+	defMap["authenticationFlowBindingOverrides"] = overrides
+	result, err := json.Marshal(defMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal definition after flow alias resolution: %w", err)
+	}
+	return result, nil
+}

--- a/internal/controller/keycloak_config_test.go
+++ b/internal/controller/keycloak_config_test.go
@@ -1,7 +1,9 @@
 package controller
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 )
 
@@ -239,6 +241,225 @@ func TestSetFieldInDefinition(t *testing.T) {
 				if gotMap[k] != v {
 					t.Errorf("field %q: got %v, want %v", k, gotMap[k], v)
 				}
+			}
+		})
+	}
+}
+
+func TestResolveFlowBindingAliases(t *testing.T) {
+	ctx := context.Background()
+	realmName := "test-realm"
+
+	fakeLookup := func(_ context.Context, _ string, alias string) (string, error) {
+		switch alias {
+		case "custom-browser-flow":
+			return "uuid-browser-1234", nil
+		case "custom-direct-grant":
+			return "uuid-direct-5678", nil
+		default:
+			return "", fmt.Errorf("authentication flow not found: %s", alias)
+		}
+	}
+
+	tests := []struct {
+		name       string
+		definition string
+		wantErr    bool
+		errContain string
+		check      func(t *testing.T, result json.RawMessage)
+	}{
+		{
+			name:       "no authenticationFlowBindingOverrides passes through",
+			definition: `{"clientId":"my-client","enabled":true}`,
+			check: func(t *testing.T, result json.RawMessage) {
+				var m map[string]interface{}
+				if err := json.Unmarshal(result, &m); err != nil {
+					t.Fatal(err)
+				}
+				if _, ok := m["authenticationFlowBindingOverrides"]; ok {
+					t.Error("expected no authenticationFlowBindingOverrides")
+				}
+			},
+		},
+		{
+			name:       "empty overrides passes through",
+			definition: `{"clientId":"my-client","authenticationFlowBindingOverrides":{}}`,
+			check: func(t *testing.T, result json.RawMessage) {
+				var m map[string]interface{}
+				if err := json.Unmarshal(result, &m); err != nil {
+					t.Fatal(err)
+				}
+				overrides := m["authenticationFlowBindingOverrides"].(map[string]interface{})
+				if len(overrides) != 0 {
+					t.Errorf("expected empty overrides, got %v", overrides)
+				}
+			},
+		},
+		{
+			name:       "UUID-based keys pass through unchanged",
+			definition: `{"authenticationFlowBindingOverrides":{"browser":"existing-uuid","direct_grant":"another-uuid"}}`,
+			check: func(t *testing.T, result json.RawMessage) {
+				var m map[string]interface{}
+				if err := json.Unmarshal(result, &m); err != nil {
+					t.Fatal(err)
+				}
+				overrides := m["authenticationFlowBindingOverrides"].(map[string]interface{})
+				if overrides["browser"] != "existing-uuid" {
+					t.Errorf("browser: got %v, want existing-uuid", overrides["browser"])
+				}
+				if overrides["direct_grant"] != "another-uuid" {
+					t.Errorf("direct_grant: got %v, want another-uuid", overrides["direct_grant"])
+				}
+			},
+		},
+		{
+			name:       "browserFlowAlias resolves to browser UUID",
+			definition: `{"authenticationFlowBindingOverrides":{"browserFlowAlias":"custom-browser-flow"}}`,
+			check: func(t *testing.T, result json.RawMessage) {
+				var m map[string]interface{}
+				if err := json.Unmarshal(result, &m); err != nil {
+					t.Fatal(err)
+				}
+				overrides := m["authenticationFlowBindingOverrides"].(map[string]interface{})
+				if overrides["browser"] != "uuid-browser-1234" {
+					t.Errorf("browser: got %v, want uuid-browser-1234", overrides["browser"])
+				}
+				if _, ok := overrides["browserFlowAlias"]; ok {
+					t.Error("browserFlowAlias should have been removed")
+				}
+			},
+		},
+		{
+			name:       "directGrantFlowAlias resolves to direct_grant UUID",
+			definition: `{"authenticationFlowBindingOverrides":{"directGrantFlowAlias":"custom-direct-grant"}}`,
+			check: func(t *testing.T, result json.RawMessage) {
+				var m map[string]interface{}
+				if err := json.Unmarshal(result, &m); err != nil {
+					t.Fatal(err)
+				}
+				overrides := m["authenticationFlowBindingOverrides"].(map[string]interface{})
+				if overrides["direct_grant"] != "uuid-direct-5678" {
+					t.Errorf("direct_grant: got %v, want uuid-direct-5678", overrides["direct_grant"])
+				}
+				if _, ok := overrides["directGrantFlowAlias"]; ok {
+					t.Error("directGrantFlowAlias should have been removed")
+				}
+			},
+		},
+		{
+			name:       "both aliases resolve together",
+			definition: `{"authenticationFlowBindingOverrides":{"browserFlowAlias":"custom-browser-flow","directGrantFlowAlias":"custom-direct-grant"}}`,
+			check: func(t *testing.T, result json.RawMessage) {
+				var m map[string]interface{}
+				if err := json.Unmarshal(result, &m); err != nil {
+					t.Fatal(err)
+				}
+				overrides := m["authenticationFlowBindingOverrides"].(map[string]interface{})
+				if overrides["browser"] != "uuid-browser-1234" {
+					t.Errorf("browser: got %v, want uuid-browser-1234", overrides["browser"])
+				}
+				if overrides["direct_grant"] != "uuid-direct-5678" {
+					t.Errorf("direct_grant: got %v, want uuid-direct-5678", overrides["direct_grant"])
+				}
+			},
+		},
+		{
+			name:       "alias takes precedence over UUID key",
+			definition: `{"authenticationFlowBindingOverrides":{"browser":"old-uuid","browserFlowAlias":"custom-browser-flow"}}`,
+			check: func(t *testing.T, result json.RawMessage) {
+				var m map[string]interface{}
+				if err := json.Unmarshal(result, &m); err != nil {
+					t.Fatal(err)
+				}
+				overrides := m["authenticationFlowBindingOverrides"].(map[string]interface{})
+				if overrides["browser"] != "uuid-browser-1234" {
+					t.Errorf("browser: got %v, want uuid-browser-1234 (alias should win)", overrides["browser"])
+				}
+			},
+		},
+		{
+			name:       "unknown alias returns error",
+			definition: `{"authenticationFlowBindingOverrides":{"browserFlowAlias":"nonexistent-flow"}}`,
+			wantErr:    true,
+			errContain: "nonexistent-flow",
+		},
+		{
+			name:       "empty alias value returns error",
+			definition: `{"authenticationFlowBindingOverrides":{"browserFlowAlias":""}}`,
+			wantErr:    true,
+			errContain: "non-empty string",
+		},
+		{
+			name:       "invalid JSON passes through unchanged",
+			definition: `{invalid`,
+			check: func(t *testing.T, result json.RawMessage) {
+				if string(result) != `{invalid` {
+					t.Errorf("expected original to be returned, got %s", string(result))
+				}
+			},
+		},
+		{
+			name:       "non-map overrides passes through unchanged",
+			definition: `{"authenticationFlowBindingOverrides":"not-a-map"}`,
+			check: func(t *testing.T, result json.RawMessage) {
+				var m map[string]interface{}
+				if err := json.Unmarshal(result, &m); err != nil {
+					t.Fatal(err)
+				}
+				if m["authenticationFlowBindingOverrides"] != "not-a-map" {
+					t.Errorf("expected unchanged, got %v", m["authenticationFlowBindingOverrides"])
+				}
+			},
+		},
+		{
+			name:       "other definition fields are preserved",
+			definition: `{"clientId":"test","enabled":true,"authenticationFlowBindingOverrides":{"browserFlowAlias":"custom-browser-flow"}}`,
+			check: func(t *testing.T, result json.RawMessage) {
+				var m map[string]interface{}
+				if err := json.Unmarshal(result, &m); err != nil {
+					t.Fatal(err)
+				}
+				if m["clientId"] != "test" {
+					t.Errorf("clientId should be preserved, got %v", m["clientId"])
+				}
+				if m["enabled"] != true {
+					t.Errorf("enabled should be preserved, got %v", m["enabled"])
+				}
+				overrides := m["authenticationFlowBindingOverrides"].(map[string]interface{})
+				if overrides["browser"] != "uuid-browser-1234" {
+					t.Errorf("browser: got %v, want uuid-browser-1234", overrides["browser"])
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := resolveFlowBindingAliasesWithLookup(ctx, realmName, json.RawMessage(tt.definition), fakeLookup)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.errContain != "" {
+					errStr := err.Error()
+					found := false
+					for i := 0; i <= len(errStr)-len(tt.errContain); i++ {
+						if errStr[i:i+len(tt.errContain)] == tt.errContain {
+							found = true
+							break
+						}
+					}
+					if !found {
+						t.Errorf("error %q should contain %q", errStr, tt.errContain)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.check != nil {
+				tt.check(t, result)
 			}
 		})
 	}

--- a/internal/controller/keycloakclient_controller.go
+++ b/internal/controller/keycloakclient_controller.go
@@ -143,6 +143,13 @@ func (r *KeycloakClientReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 	}
 
+	// Resolve authentication flow binding aliases to UUIDs
+	definition, err = resolveFlowBindingAliases(ctx, kc, realmName, definition)
+	if err != nil {
+		RecordError(controllerName, "flow_alias_error")
+		return r.updateStatus(ctx, kcClient, false, "FlowAliasResolutionFailed", fmt.Sprintf("Failed to resolve flow alias: %v", err), "", instanceRef, realmRef)
+	}
+
 	// Check if client exists
 	existingClient, err := kc.GetClientByClientID(ctx, realmName, clientDef.ClientID)
 

--- a/internal/keycloak/client.go
+++ b/internal/keycloak/client.go
@@ -1171,6 +1171,39 @@ func (c *Client) DeleteRequiredAction(ctx context.Context, realmName, alias stri
 }
 
 // ============================================================================
+// Authentication Flow Operations
+// ============================================================================
+
+// AuthenticationFlowRepresentation represents a Keycloak authentication flow
+type AuthenticationFlowRepresentation struct {
+	ID    string `json:"id"`
+	Alias string `json:"alias"`
+}
+
+// GetAuthenticationFlows lists all authentication flows in a realm
+func (c *Client) GetAuthenticationFlows(ctx context.Context, realmName string) ([]AuthenticationFlowRepresentation, error) {
+	var flows []AuthenticationFlowRepresentation
+	if err := c.List(ctx, "/admin/realms/"+url.PathEscape(realmName)+"/authentication/flows", nil, &flows); err != nil {
+		return nil, err
+	}
+	return flows, nil
+}
+
+// GetAuthenticationFlowByAlias finds an authentication flow by its alias
+func (c *Client) GetAuthenticationFlowByAlias(ctx context.Context, realmName, alias string) (*AuthenticationFlowRepresentation, error) {
+	flows, err := c.GetAuthenticationFlows(ctx, realmName)
+	if err != nil {
+		return nil, err
+	}
+	for i := range flows {
+		if flows[i].Alias == alias {
+			return &flows[i], nil
+		}
+	}
+	return nil, fmt.Errorf("authentication flow not found: %s", alias)
+}
+
+// ============================================================================
 // Raw JSON Operations (for export)
 // ============================================================================
 

--- a/test/e2e/client_test.go
+++ b/test/e2e/client_test.go
@@ -702,4 +702,48 @@ func TestKeycloakClientE2E(t *testing.T) {
 		require.NoError(t, err, "Client was not recreated in Keycloak after deletion")
 		t.Log("Client was successfully reconciled (recreated) after manual deletion")
 	})
+
+	t.Run("ClientWithFlowBindingAlias", func(t *testing.T) {
+		// Create a client using browserFlowAlias instead of a UUID.
+		// "browser" is the default authentication flow alias in every Keycloak realm.
+		clientName := fmt.Sprintf("flow-alias-client-%d", time.Now().UnixNano())
+		clientDef := rawJSON(fmt.Sprintf(`{
+			"clientId": "%s",
+			"name": "Flow Alias Client",
+			"enabled": true,
+			"publicClient": true,
+			"standardFlowEnabled": true,
+			"authenticationFlowBindingOverrides": {
+				"browserFlowAlias": "browser"
+			}
+		}`, clientName))
+		kcClient := &keycloakv1beta1.KeycloakClient{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clientName,
+				Namespace: testNamespace,
+			},
+			Spec: keycloakv1beta1.KeycloakClientSpec{
+				RealmRef:   &keycloakv1beta1.ResourceRef{Name: realmName},
+				Definition: &clientDef,
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, kcClient))
+		t.Cleanup(func() {
+			k8sClient.Delete(ctx, kcClient)
+		})
+
+		// Wait for client to be ready — this proves the alias was resolved
+		err := wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+			updated := &keycloakv1beta1.KeycloakClient{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      kcClient.Name,
+				Namespace: kcClient.Namespace,
+			}, updated); err != nil {
+				return false, nil
+			}
+			return updated.Status.Ready, nil
+		})
+		require.NoError(t, err, "Client with browserFlowAlias did not become ready")
+		t.Logf("Client %s with browserFlowAlias is ready", clientName)
+	})
 }


### PR DESCRIPTION
Allow referencing authentication flows by alias instead of UUID in authenticationFlowBindingOverrides, enabling fully declarative client configuration in GitOps workflows. Closes #40 