### PR TITLE
Fix nil pointer panic when KeycloakRealm uses clusterInstanceRef

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,11 @@ make kind-redeploy
 # Run unit tests (fast, no cluster required)
 make test
 
-# Run full E2E tests (requires Kind cluster)
-make kind-test
+# Run full E2E tests (requires Kind cluster with operator deployed)
+make kind-test-run
+
+# Run a specific E2E test
+make kind-test-run TEST_RUN=TestKeycloakRealmE2E
 ```
 
 ## Monitoring

--- a/internal/controller/keycloak_config.go
+++ b/internal/controller/keycloak_config.go
@@ -206,6 +206,60 @@ func mergeSmtpCredentials(definition json.RawMessage, user, password string) jso
 	return result
 }
 
+// GetKeycloakClientFromRealmInstance resolves the Keycloak API client for a
+// KeycloakRealm by following its instanceRef or clusterInstanceRef. This is the
+// single source of truth for realm→instance resolution in all child-resource
+// controllers (client, user, group, role, etc.).
+func GetKeycloakClientFromRealmInstance(ctx context.Context, c client.Client, clientManager *keycloak.ClientManager, realm *keycloakv1beta1.KeycloakRealm) (*keycloak.Client, error) {
+	if realm.Spec.ClusterInstanceRef != nil {
+		instance := &keycloakv1beta1.ClusterKeycloakInstance{}
+		if err := c.Get(ctx, types.NamespacedName{Name: realm.Spec.ClusterInstanceRef.Name}, instance); err != nil {
+			return nil, fmt.Errorf("failed to get ClusterKeycloakInstance %s: %w", realm.Spec.ClusterInstanceRef.Name, err)
+		}
+		if !instance.Status.Ready {
+			return nil, fmt.Errorf("ClusterKeycloakInstance %s is not ready", realm.Spec.ClusterInstanceRef.Name)
+		}
+		cfg, err := GetKeycloakConfigFromClusterInstance(ctx, c, instance)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get Keycloak config from ClusterKeycloakInstance %s: %w", realm.Spec.ClusterInstanceRef.Name, err)
+		}
+		kc := clientManager.GetOrCreateClient(clusterInstanceKey(realm.Spec.ClusterInstanceRef.Name), cfg)
+		if kc == nil {
+			return nil, fmt.Errorf("Keycloak client not available for cluster instance %s", realm.Spec.ClusterInstanceRef.Name)
+		}
+		return kc, nil
+	}
+
+	if realm.Spec.InstanceRef != nil {
+		instanceNamespace := realm.Namespace
+		if realm.Spec.InstanceRef.Namespace != nil {
+			instanceNamespace = *realm.Spec.InstanceRef.Namespace
+		}
+		instanceName := types.NamespacedName{
+			Name:      realm.Spec.InstanceRef.Name,
+			Namespace: instanceNamespace,
+		}
+		instance := &keycloakv1beta1.KeycloakInstance{}
+		if err := c.Get(ctx, instanceName, instance); err != nil {
+			return nil, fmt.Errorf("failed to get KeycloakInstance %s: %w", instanceName, err)
+		}
+		if !instance.Status.Ready {
+			return nil, fmt.Errorf("KeycloakInstance %s is not ready", instanceName)
+		}
+		cfg, err := GetKeycloakConfigFromInstance(ctx, c, instance)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get Keycloak config from KeycloakInstance %s: %w", instanceName, err)
+		}
+		kc := clientManager.GetOrCreateClient(instanceName.String(), cfg)
+		if kc == nil {
+			return nil, fmt.Errorf("Keycloak client not available for instance %s", instanceName)
+		}
+		return kc, nil
+	}
+
+	return nil, fmt.Errorf("realm %s/%s has neither instanceRef nor clusterInstanceRef", realm.Namespace, realm.Name)
+}
+
 // mergeIDPConfig merges the given key-value pairs into definition.config.
 // If the config map doesn't exist yet, it is created. Values in secretData
 // take precedence over existing entries in definition.config.

--- a/internal/controller/keycloakclient_controller.go
+++ b/internal/controller/keycloakclient_controller.go
@@ -239,37 +239,10 @@ func (r *KeycloakClientReconciler) getKeycloakClientAndRealm(ctx context.Context
 		return nil, "", instanceRef, realmRef, fmt.Errorf("failed to parse realm definition: %w", err)
 	}
 
-	// Get instance reference from realm
-	instanceNamespace := realm.Namespace
-	if realm.Spec.InstanceRef.Namespace != nil {
-		instanceNamespace = *realm.Spec.InstanceRef.Namespace
-	}
-	instanceName := types.NamespacedName{
-		Name:      realm.Spec.InstanceRef.Name,
-		Namespace: instanceNamespace,
-	}
-	instanceRef.InstanceRef = fmt.Sprintf("%s/%s", instanceNamespace, realm.Spec.InstanceRef.Name)
-
-	// Get the KeycloakInstance
-	instance := &keycloakv1beta1.KeycloakInstance{}
-	if err := r.Get(ctx, instanceName, instance); err != nil {
-		return nil, "", instanceRef, realmRef, fmt.Errorf("failed to get KeycloakInstance %s: %w", instanceName, err)
-	}
-
-	// Check if instance is ready
-	if !instance.Status.Ready {
-		return nil, "", instanceRef, realmRef, fmt.Errorf("KeycloakInstance %s is not ready", instanceName)
-	}
-
-	// Get the Keycloak client from manager
-	cfg, err := GetKeycloakConfigFromInstance(ctx, r.Client, instance)
+	// Get Keycloak client from realm's instance
+	kc, err := GetKeycloakClientFromRealmInstance(ctx, r.Client, r.ClientManager, realm)
 	if err != nil {
-		return nil, "", instanceRef, realmRef, fmt.Errorf("failed to get Keycloak config from KeycloakInstance %s: %w", instanceName, err)
-	}
-
-	kc := r.ClientManager.GetOrCreateClient(instanceName.String(), cfg)
-	if kc == nil {
-		return nil, "", instanceRef, realmRef, fmt.Errorf("keycloak client not available for instance %s", instanceName)
+		return nil, "", instanceRef, realmRef, err
 	}
 
 	return kc, realmDef.Realm, instanceRef, realmRef, nil

--- a/internal/controller/keycloakclientscope_controller.go
+++ b/internal/controller/keycloakclientscope_controller.go
@@ -183,37 +183,9 @@ func (r *KeycloakClientScopeReconciler) getKeycloakClientAndRealm(ctx context.Co
 		return nil, "", fmt.Errorf("failed to parse realm definition: %w", err)
 	}
 
-	// Get instance reference from realm
-	if realm.Spec.InstanceRef == nil {
-		return nil, "", fmt.Errorf("realm %s has no instanceRef", realmName)
-	}
-
-	instanceNamespace := realm.Namespace
-	if realm.Spec.InstanceRef.Namespace != nil {
-		instanceNamespace = *realm.Spec.InstanceRef.Namespace
-	}
-	instanceName := types.NamespacedName{
-		Name:      realm.Spec.InstanceRef.Name,
-		Namespace: instanceNamespace,
-	}
-
-	instance := &keycloakv1beta1.KeycloakInstance{}
-	if err := r.Get(ctx, instanceName, instance); err != nil {
-		return nil, "", fmt.Errorf("failed to get KeycloakInstance %s: %w", instanceName, err)
-	}
-
-	if !instance.Status.Ready {
-		return nil, "", fmt.Errorf("KeycloakInstance %s is not ready", instanceName)
-	}
-
-	cfg, err := GetKeycloakConfigFromInstance(ctx, r.Client, instance)
+	kc, err := GetKeycloakClientFromRealmInstance(ctx, r.Client, r.ClientManager, realm)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to get Keycloak config from KeycloakInstance %s: %w", instanceName, err)
-	}
-
-	kc := r.ClientManager.GetOrCreateClient(instanceName.String(), cfg)
-	if kc == nil {
-		return nil, "", fmt.Errorf("Keycloak client not available for instance %s", instanceName)
+		return nil, "", err
 	}
 
 	return kc, realmDef.Realm, nil

--- a/internal/controller/keycloakcomponent_controller.go
+++ b/internal/controller/keycloakcomponent_controller.go
@@ -191,37 +191,9 @@ func (r *KeycloakComponentReconciler) getKeycloakClientAndRealm(ctx context.Cont
 		return nil, "", "", fmt.Errorf("failed to parse realm definition: %w", err)
 	}
 
-	// Get instance reference from realm
-	if realm.Spec.InstanceRef == nil {
-		return nil, "", "", fmt.Errorf("realm %s has no instanceRef", realmName)
-	}
-
-	instanceNamespace := realm.Namespace
-	if realm.Spec.InstanceRef.Namespace != nil {
-		instanceNamespace = *realm.Spec.InstanceRef.Namespace
-	}
-	instanceName := types.NamespacedName{
-		Name:      realm.Spec.InstanceRef.Name,
-		Namespace: instanceNamespace,
-	}
-
-	instance := &keycloakv1beta1.KeycloakInstance{}
-	if err := r.Get(ctx, instanceName, instance); err != nil {
-		return nil, "", "", fmt.Errorf("failed to get KeycloakInstance %s: %w", instanceName, err)
-	}
-
-	if !instance.Status.Ready {
-		return nil, "", "", fmt.Errorf("KeycloakInstance %s is not ready", instanceName)
-	}
-
-	cfg, err := GetKeycloakConfigFromInstance(ctx, r.Client, instance)
+	kc, err := GetKeycloakClientFromRealmInstance(ctx, r.Client, r.ClientManager, realm)
 	if err != nil {
-		return nil, "", "", fmt.Errorf("failed to get Keycloak config from KeycloakInstance %s: %w", instanceName, err)
-	}
-
-	kc := r.ClientManager.GetOrCreateClient(instanceName.String(), cfg)
-	if kc == nil {
-		return nil, "", "", fmt.Errorf("Keycloak client not available for instance %s", instanceName)
+		return nil, "", "", err
 	}
 
 	// Get the realm ID from Keycloak if not in definition

--- a/internal/controller/keycloakgroup_controller.go
+++ b/internal/controller/keycloakgroup_controller.go
@@ -233,37 +233,9 @@ func (r *KeycloakGroupReconciler) getKeycloakClientAndRealm(ctx context.Context,
 		return nil, "", fmt.Errorf("failed to parse realm definition: %w", err)
 	}
 
-	// Get instance reference from realm
-	if realm.Spec.InstanceRef == nil {
-		return nil, "", fmt.Errorf("realm %s has no instanceRef", realmName)
-	}
-
-	instanceNamespace := realm.Namespace
-	if realm.Spec.InstanceRef.Namespace != nil {
-		instanceNamespace = *realm.Spec.InstanceRef.Namespace
-	}
-	instanceName := types.NamespacedName{
-		Name:      realm.Spec.InstanceRef.Name,
-		Namespace: instanceNamespace,
-	}
-
-	instance := &keycloakv1beta1.KeycloakInstance{}
-	if err := r.Get(ctx, instanceName, instance); err != nil {
-		return nil, "", fmt.Errorf("failed to get KeycloakInstance %s: %w", instanceName, err)
-	}
-
-	if !instance.Status.Ready {
-		return nil, "", fmt.Errorf("KeycloakInstance %s is not ready", instanceName)
-	}
-
-	cfg, err := GetKeycloakConfigFromInstance(ctx, r.Client, instance)
+	kc, err := GetKeycloakClientFromRealmInstance(ctx, r.Client, r.ClientManager, realm)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to get Keycloak config from KeycloakInstance %s: %w", instanceName, err)
-	}
-
-	kc := r.ClientManager.GetOrCreateClient(instanceName.String(), cfg)
-	if kc == nil {
-		return nil, "", fmt.Errorf("Keycloak client not available for instance %s", instanceName)
+		return nil, "", err
 	}
 
 	return kc, realmDef.Realm, nil

--- a/internal/controller/keycloakidentityprovider_controller.go
+++ b/internal/controller/keycloakidentityprovider_controller.go
@@ -184,37 +184,9 @@ func (r *KeycloakIdentityProviderReconciler) getKeycloakClientAndRealm(ctx conte
 		return nil, "", fmt.Errorf("failed to parse realm definition: %w", err)
 	}
 
-	// Get instance reference from realm
-	if realm.Spec.InstanceRef == nil {
-		return nil, "", fmt.Errorf("realm %s has no instanceRef", realmName)
-	}
-
-	instanceNamespace := realm.Namespace
-	if realm.Spec.InstanceRef.Namespace != nil {
-		instanceNamespace = *realm.Spec.InstanceRef.Namespace
-	}
-	instanceName := types.NamespacedName{
-		Name:      realm.Spec.InstanceRef.Name,
-		Namespace: instanceNamespace,
-	}
-
-	instance := &keycloakv1beta1.KeycloakInstance{}
-	if err := r.Get(ctx, instanceName, instance); err != nil {
-		return nil, "", fmt.Errorf("failed to get KeycloakInstance %s: %w", instanceName, err)
-	}
-
-	if !instance.Status.Ready {
-		return nil, "", fmt.Errorf("KeycloakInstance %s is not ready", instanceName)
-	}
-
-	cfg, err := GetKeycloakConfigFromInstance(ctx, r.Client, instance)
+	kc, err := GetKeycloakClientFromRealmInstance(ctx, r.Client, r.ClientManager, realm)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to get Keycloak config from KeycloakInstance %s: %w", instanceName, err)
-	}
-
-	kc := r.ClientManager.GetOrCreateClient(instanceName.String(), cfg)
-	if kc == nil {
-		return nil, "", fmt.Errorf("Keycloak client not available for instance %s", instanceName)
+		return nil, "", err
 	}
 
 	return kc, realmDef.Realm, nil

--- a/internal/controller/keycloakorganization_controller.go
+++ b/internal/controller/keycloakorganization_controller.go
@@ -225,42 +225,12 @@ func (r *KeycloakOrganizationReconciler) getKeycloakClientRealmAndVersion(ctx co
 		return nil, "", "", fmt.Errorf("failed to parse realm definition: %w", err)
 	}
 
-	// Get instance reference from realm
-	instanceNamespace := realm.Namespace
-	if realm.Spec.InstanceRef.Namespace != nil {
-		instanceNamespace = *realm.Spec.InstanceRef.Namespace
-	}
-	instanceName := types.NamespacedName{
-		Name:      realm.Spec.InstanceRef.Name,
-		Namespace: instanceNamespace,
-	}
-
-	// Get the KeycloakInstance
-	instance := &keycloakv1beta1.KeycloakInstance{}
-	if err := r.Get(ctx, instanceName, instance); err != nil {
-		return nil, "", "", fmt.Errorf("failed to get KeycloakInstance %s: %w", instanceName, err)
-	}
-
-	// Check if instance is ready
-	if !instance.Status.Ready {
-		return nil, "", "", fmt.Errorf("KeycloakInstance %s is not ready", instanceName)
-	}
-
-	// Get Keycloak version from instance status
-	keycloakVersion := instance.Status.Version
-
-	// Get the Keycloak client from manager
-	cfg, err := GetKeycloakConfigFromInstance(ctx, r.Client, instance)
+	kc, err := GetKeycloakClientFromRealmInstance(ctx, r.Client, r.ClientManager, realm)
 	if err != nil {
-		return nil, "", "", fmt.Errorf("failed to get Keycloak config from KeycloakInstance %s: %w", instanceName, err)
+		return nil, "", "", err
 	}
 
-	kc := r.ClientManager.GetOrCreateClient(instanceName.String(), cfg)
-	if kc == nil {
-		return nil, "", "", fmt.Errorf("Keycloak client not available for instance %s", instanceName)
-	}
-
-	return kc, realmDef.Realm, keycloakVersion, nil
+	return kc, realmDef.Realm, "", nil
 }
 
 func (r *KeycloakOrganizationReconciler) getKeycloakClientFromClusterRealm(ctx context.Context, clusterRealmName string) (*keycloak.Client, string, string, error) {

--- a/internal/controller/keycloakprotocolmapper_controller.go
+++ b/internal/controller/keycloakprotocolmapper_controller.go
@@ -284,37 +284,9 @@ func (r *KeycloakProtocolMapperReconciler) getKeycloakClientAndRealmFromClient(c
 		return nil, "", fmt.Errorf("failed to parse realm definition: %w", err)
 	}
 
-	// Get instance
-	if realm.Spec.InstanceRef == nil {
-		return nil, "", fmt.Errorf("realm %s has no instanceRef", realmName)
-	}
-
-	instanceNamespace := realm.Namespace
-	if realm.Spec.InstanceRef.Namespace != nil {
-		instanceNamespace = *realm.Spec.InstanceRef.Namespace
-	}
-	instanceName := types.NamespacedName{
-		Name:      realm.Spec.InstanceRef.Name,
-		Namespace: instanceNamespace,
-	}
-
-	instance := &keycloakv1beta1.KeycloakInstance{}
-	if err := r.Get(ctx, instanceName, instance); err != nil {
-		return nil, "", fmt.Errorf("failed to get KeycloakInstance %s: %w", instanceName, err)
-	}
-
-	if !instance.Status.Ready {
-		return nil, "", fmt.Errorf("KeycloakInstance %s is not ready", instanceName)
-	}
-
-	cfg, err := GetKeycloakConfigFromInstance(ctx, r.Client, instance)
+	kc, err := GetKeycloakClientFromRealmInstance(ctx, r.Client, r.ClientManager, realm)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to get Keycloak config: %w", err)
-	}
-
-	kc := r.ClientManager.GetOrCreateClient(instanceName.String(), cfg)
-	if kc == nil {
-		return nil, "", fmt.Errorf("Keycloak client not available for instance %s", instanceName)
+		return nil, "", err
 	}
 
 	return kc, realmDef.Realm, nil
@@ -356,37 +328,9 @@ func (r *KeycloakProtocolMapperReconciler) getKeycloakClientAndRealmFromScope(ct
 		return nil, "", fmt.Errorf("failed to parse realm definition: %w", err)
 	}
 
-	// Get instance
-	if realm.Spec.InstanceRef == nil {
-		return nil, "", fmt.Errorf("realm %s has no instanceRef", realmName)
-	}
-
-	instanceNamespace := realm.Namespace
-	if realm.Spec.InstanceRef.Namespace != nil {
-		instanceNamespace = *realm.Spec.InstanceRef.Namespace
-	}
-	instanceName := types.NamespacedName{
-		Name:      realm.Spec.InstanceRef.Name,
-		Namespace: instanceNamespace,
-	}
-
-	instance := &keycloakv1beta1.KeycloakInstance{}
-	if err := r.Get(ctx, instanceName, instance); err != nil {
-		return nil, "", fmt.Errorf("failed to get KeycloakInstance %s: %w", instanceName, err)
-	}
-
-	if !instance.Status.Ready {
-		return nil, "", fmt.Errorf("KeycloakInstance %s is not ready", instanceName)
-	}
-
-	cfg, err := GetKeycloakConfigFromInstance(ctx, r.Client, instance)
+	kc, err := GetKeycloakClientFromRealmInstance(ctx, r.Client, r.ClientManager, realm)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to get Keycloak config: %w", err)
-	}
-
-	kc := r.ClientManager.GetOrCreateClient(instanceName.String(), cfg)
-	if kc == nil {
-		return nil, "", fmt.Errorf("Keycloak client not available for instance %s", instanceName)
+		return nil, "", err
 	}
 
 	return kc, realmDef.Realm, nil

--- a/internal/controller/keycloakrealm_controller.go
+++ b/internal/controller/keycloakrealm_controller.go
@@ -147,45 +147,70 @@ func (r *KeycloakRealmReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 }
 
 func (r *KeycloakRealmReconciler) getKeycloakClient(ctx context.Context, realm *keycloakv1beta1.KeycloakRealm) (*keycloak.Client, *keycloakv1beta1.InstanceRef, error) {
-	// Get the instance reference
-	instanceNamespace := realm.Namespace
-	if realm.Spec.InstanceRef.Namespace != nil {
-		instanceNamespace = *realm.Spec.InstanceRef.Namespace
-	}
-	instanceName := types.NamespacedName{
-		Name:      realm.Spec.InstanceRef.Name,
-		Namespace: instanceNamespace,
+	if realm.Spec.ClusterInstanceRef != nil {
+		instanceRef := &keycloakv1beta1.InstanceRef{
+			ClusterInstanceRef: realm.Spec.ClusterInstanceRef.Name,
+		}
+
+		instance := &keycloakv1beta1.ClusterKeycloakInstance{}
+		if err := r.Get(ctx, types.NamespacedName{Name: realm.Spec.ClusterInstanceRef.Name}, instance); err != nil {
+			return nil, instanceRef, fmt.Errorf("failed to get ClusterKeycloakInstance %s: %w", realm.Spec.ClusterInstanceRef.Name, err)
+		}
+
+		if !instance.Status.Ready {
+			return nil, instanceRef, fmt.Errorf("ClusterKeycloakInstance %s is not ready", realm.Spec.ClusterInstanceRef.Name)
+		}
+
+		cfg, err := GetKeycloakConfigFromClusterInstance(ctx, r.Client, instance)
+		if err != nil {
+			return nil, instanceRef, fmt.Errorf("failed to get Keycloak config from ClusterKeycloakInstance %s: %w", realm.Spec.ClusterInstanceRef.Name, err)
+		}
+
+		kc := r.ClientManager.GetOrCreateClient(clusterInstanceKey(realm.Spec.ClusterInstanceRef.Name), cfg)
+		if kc == nil {
+			return nil, instanceRef, fmt.Errorf("Keycloak client not available for cluster instance %s", realm.Spec.ClusterInstanceRef.Name)
+		}
+
+		return kc, instanceRef, nil
 	}
 
-	// Create instance ref for status
-	instanceRef := &keycloakv1beta1.InstanceRef{
-		InstanceRef: fmt.Sprintf("%s/%s", instanceNamespace, realm.Spec.InstanceRef.Name),
+	if realm.Spec.InstanceRef != nil {
+		instanceNamespace := realm.Namespace
+		if realm.Spec.InstanceRef.Namespace != nil {
+			instanceNamespace = *realm.Spec.InstanceRef.Namespace
+		}
+		instanceName := types.NamespacedName{
+			Name:      realm.Spec.InstanceRef.Name,
+			Namespace: instanceNamespace,
+		}
+
+		instanceRef := &keycloakv1beta1.InstanceRef{
+			InstanceRef: fmt.Sprintf("%s/%s", instanceNamespace, realm.Spec.InstanceRef.Name),
+		}
+
+		instance := &keycloakv1beta1.KeycloakInstance{}
+		if err := r.Get(ctx, instanceName, instance); err != nil {
+			return nil, instanceRef, fmt.Errorf("failed to get KeycloakInstance %s: %w", instanceName, err)
+		}
+
+		if !instance.Status.Ready {
+			return nil, instanceRef, fmt.Errorf("KeycloakInstance %s is not ready", instanceName)
+		}
+
+		cfg, err := GetKeycloakConfigFromInstance(ctx, r.Client, instance)
+		if err != nil {
+			return nil, instanceRef, fmt.Errorf("failed to get Keycloak config: %w", err)
+		}
+
+		kc := r.ClientManager.GetOrCreateClient(instanceName.String(), cfg)
+		if kc == nil {
+			return nil, instanceRef, fmt.Errorf("Keycloak client not available for instance %s", instanceName)
+		}
+
+		return kc, instanceRef, nil
 	}
 
-	// Get the KeycloakInstance
-	instance := &keycloakv1beta1.KeycloakInstance{}
-	if err := r.Get(ctx, instanceName, instance); err != nil {
-		return nil, instanceRef, fmt.Errorf("failed to get KeycloakInstance %s: %w", instanceName, err)
-	}
-
-	// Check if instance is ready
-	if !instance.Status.Ready {
-		return nil, instanceRef, fmt.Errorf("KeycloakInstance %s is not ready", instanceName)
-	}
-
-	// Build config from instance
-	cfg, err := GetKeycloakConfigFromInstance(ctx, r.Client, instance)
-	if err != nil {
-		return nil, instanceRef, fmt.Errorf("failed to get Keycloak config: %w", err)
-	}
-
-	// Get the Keycloak client from manager
-	kc := r.ClientManager.GetOrCreateClient(instanceName.String(), cfg)
-	if kc == nil {
-		return nil, instanceRef, fmt.Errorf("Keycloak client not available for instance %s", instanceName)
-	}
-
-	return kc, instanceRef, nil
+	return nil, nil, fmt.Errorf("either instanceRef or clusterInstanceRef must be specified")
 }
 
 func (r *KeycloakRealmReconciler) deleteRealm(ctx context.Context, realm *keycloakv1beta1.KeycloakRealm) error {

--- a/internal/controller/keycloakrequiredaction_controller.go
+++ b/internal/controller/keycloakrequiredaction_controller.go
@@ -197,36 +197,9 @@ func (r *KeycloakRequiredActionReconciler) getKeycloakClientAndRealm(ctx context
 		return nil, "", fmt.Errorf("failed to parse realm definition: %w", err)
 	}
 
-	if realm.Spec.InstanceRef == nil {
-		return nil, "", fmt.Errorf("realm %s has no instanceRef", realmKey)
-	}
-
-	instanceNamespace := realm.Namespace
-	if realm.Spec.InstanceRef.Namespace != nil {
-		instanceNamespace = *realm.Spec.InstanceRef.Namespace
-	}
-	instanceKey := types.NamespacedName{
-		Name:      realm.Spec.InstanceRef.Name,
-		Namespace: instanceNamespace,
-	}
-
-	instance := &keycloakv1beta1.KeycloakInstance{}
-	if err := r.Get(ctx, instanceKey, instance); err != nil {
-		return nil, "", fmt.Errorf("failed to get KeycloakInstance %s: %w", instanceKey, err)
-	}
-
-	if !instance.Status.Ready {
-		return nil, "", fmt.Errorf("KeycloakInstance %s is not ready", instanceKey)
-	}
-
-	cfg, err := GetKeycloakConfigFromInstance(ctx, r.Client, instance)
+	kc, err := GetKeycloakClientFromRealmInstance(ctx, r.Client, r.ClientManager, realm)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to get Keycloak config: %w", err)
-	}
-
-	kc := r.ClientManager.GetOrCreateClient(instanceKey.String(), cfg)
-	if kc == nil {
-		return nil, "", fmt.Errorf("Keycloak client not available for instance %s", instanceKey)
+		return nil, "", err
 	}
 
 	return kc, realmDef.Realm, nil

--- a/internal/controller/keycloakrole_controller.go
+++ b/internal/controller/keycloakrole_controller.go
@@ -212,37 +212,9 @@ func (r *KeycloakRoleReconciler) getKeycloakClientAndRealm(ctx context.Context, 
 		return nil, "", fmt.Errorf("failed to parse realm definition: %w", err)
 	}
 
-	// Get instance reference from realm
-	if realm.Spec.InstanceRef == nil {
-		return nil, "", fmt.Errorf("realm %s has no instanceRef", realmName)
-	}
-
-	instanceNamespace := realm.Namespace
-	if realm.Spec.InstanceRef.Namespace != nil {
-		instanceNamespace = *realm.Spec.InstanceRef.Namespace
-	}
-	instanceName := types.NamespacedName{
-		Name:      realm.Spec.InstanceRef.Name,
-		Namespace: instanceNamespace,
-	}
-
-	instance := &keycloakv1beta1.KeycloakInstance{}
-	if err := r.Get(ctx, instanceName, instance); err != nil {
-		return nil, "", fmt.Errorf("failed to get KeycloakInstance %s: %w", instanceName, err)
-	}
-
-	if !instance.Status.Ready {
-		return nil, "", fmt.Errorf("KeycloakInstance %s is not ready", instanceName)
-	}
-
-	cfg, err := GetKeycloakConfigFromInstance(ctx, r.Client, instance)
+	kc, err := GetKeycloakClientFromRealmInstance(ctx, r.Client, r.ClientManager, realm)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to get Keycloak config from KeycloakInstance %s: %w", instanceName, err)
-	}
-
-	kc := r.ClientManager.GetOrCreateClient(instanceName.String(), cfg)
-	if kc == nil {
-		return nil, "", fmt.Errorf("Keycloak client not available for instance %s", instanceName)
+		return nil, "", err
 	}
 
 	return kc, realmDef.Realm, nil

--- a/internal/controller/keycloakrolemapping_controller.go
+++ b/internal/controller/keycloakrolemapping_controller.go
@@ -307,30 +307,9 @@ func (r *KeycloakRoleMappingReconciler) getKeycloakClientFromUser(ctx context.Co
 		return nil, "", fmt.Errorf("failed to parse realm definition: %w", err)
 	}
 
-	// Get the instance
-	instanceNamespace := realm.Namespace
-	if realm.Spec.InstanceRef.Namespace != nil {
-		instanceNamespace = *realm.Spec.InstanceRef.Namespace
-	}
-
-	instanceName := types.NamespacedName{Name: realm.Spec.InstanceRef.Name, Namespace: instanceNamespace}
-	instance := &keycloakv1beta1.KeycloakInstance{}
-	if err := r.Get(ctx, instanceName, instance); err != nil {
-		return nil, "", err
-	}
-
-	if !instance.Status.Ready {
-		return nil, "", fmt.Errorf("instance %s is not ready", instance.Name)
-	}
-
-	cfg, err := GetKeycloakConfigFromInstance(ctx, r.Client, instance)
+	kc, err := GetKeycloakClientFromRealmInstance(ctx, r.Client, r.ClientManager, realm)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to get Keycloak config from KeycloakInstance %s: %w", instanceName, err)
-	}
-
-	kc := r.ClientManager.GetOrCreateClient(instanceName.String(), cfg)
-	if kc == nil {
-		return nil, "", fmt.Errorf("failed to get Keycloak client")
+		return nil, "", err
 	}
 
 	return kc, realmDef.Realm, nil
@@ -369,30 +348,9 @@ func (r *KeycloakRoleMappingReconciler) getKeycloakClientFromGroup(ctx context.C
 		return nil, "", fmt.Errorf("failed to parse realm definition: %w", err)
 	}
 
-	// Get the instance
-	instanceNamespace := realm.Namespace
-	if realm.Spec.InstanceRef.Namespace != nil {
-		instanceNamespace = *realm.Spec.InstanceRef.Namespace
-	}
-
-	instanceName := types.NamespacedName{Name: realm.Spec.InstanceRef.Name, Namespace: instanceNamespace}
-	instance := &keycloakv1beta1.KeycloakInstance{}
-	if err := r.Get(ctx, instanceName, instance); err != nil {
-		return nil, "", err
-	}
-
-	if !instance.Status.Ready {
-		return nil, "", fmt.Errorf("instance %s is not ready", instance.Name)
-	}
-
-	cfg, err := GetKeycloakConfigFromInstance(ctx, r.Client, instance)
+	kc, err := GetKeycloakClientFromRealmInstance(ctx, r.Client, r.ClientManager, realm)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to get Keycloak config from KeycloakInstance %s: %w", instanceName, err)
-	}
-
-	kc := r.ClientManager.GetOrCreateClient(instanceName.String(), cfg)
-	if kc == nil {
-		return nil, "", fmt.Errorf("failed to get Keycloak client")
+		return nil, "", err
 	}
 
 	return kc, realmDef.Realm, nil

--- a/internal/controller/keycloakuser_controller.go
+++ b/internal/controller/keycloakuser_controller.go
@@ -197,36 +197,9 @@ func (r *KeycloakUserReconciler) getKeycloakClientAndRealm(ctx context.Context, 
 		return nil, "", fmt.Errorf("failed to parse realm definition: %w", err)
 	}
 
-	// Get instance reference from realm
-	instanceNamespace := realm.Namespace
-	if realm.Spec.InstanceRef.Namespace != nil {
-		instanceNamespace = *realm.Spec.InstanceRef.Namespace
-	}
-	instanceName := types.NamespacedName{
-		Name:      realm.Spec.InstanceRef.Name,
-		Namespace: instanceNamespace,
-	}
-
-	// Get the KeycloakInstance
-	instance := &keycloakv1beta1.KeycloakInstance{}
-	if err := r.Get(ctx, instanceName, instance); err != nil {
-		return nil, "", fmt.Errorf("failed to get KeycloakInstance %s: %w", instanceName, err)
-	}
-
-	// Check if instance is ready
-	if !instance.Status.Ready {
-		return nil, "", fmt.Errorf("KeycloakInstance %s is not ready", instanceName)
-	}
-
-	// Get the Keycloak client from manager
-	cfg, err := GetKeycloakConfigFromInstance(ctx, r.Client, instance)
+	kc, err := GetKeycloakClientFromRealmInstance(ctx, r.Client, r.ClientManager, realm)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to get Keycloak config from KeycloakInstance %s: %w", instanceName, err)
-	}
-
-	kc := r.ClientManager.GetOrCreateClient(instanceName.String(), cfg)
-	if kc == nil {
-		return nil, "", fmt.Errorf("Keycloak client not available for instance %s", instanceName)
+		return nil, "", err
 	}
 
 	return kc, realmDef.Realm, nil
@@ -438,33 +411,9 @@ func (r *KeycloakUserReconciler) getKeycloakClientAndRealmFromClient(ctx context
 		}
 		realmName = realmDef.Realm
 
-		// Get instance
-		instanceNamespace := realm.Namespace
-		if realm.Spec.InstanceRef.Namespace != nil {
-			instanceNamespace = *realm.Spec.InstanceRef.Namespace
-		}
-		instanceName := types.NamespacedName{
-			Name:      realm.Spec.InstanceRef.Name,
-			Namespace: instanceNamespace,
-		}
-
-		instance := &keycloakv1beta1.KeycloakInstance{}
-		if err := r.Get(ctx, instanceName, instance); err != nil {
-			return nil, "", "", fmt.Errorf("failed to get KeycloakInstance %s: %w", instanceName, err)
-		}
-
-		if !instance.Status.Ready {
-			return nil, "", "", fmt.Errorf("KeycloakInstance %s is not ready", instanceName)
-		}
-
-		cfg, err := GetKeycloakConfigFromInstance(ctx, r.Client, instance)
+		kc, err = GetKeycloakClientFromRealmInstance(ctx, r.Client, r.ClientManager, realm)
 		if err != nil {
-			return nil, "", "", fmt.Errorf("failed to get Keycloak config: %w", err)
-		}
-
-		kc = r.ClientManager.GetOrCreateClient(instanceName.String(), cfg)
-		if kc == nil {
-			return nil, "", "", fmt.Errorf("Keycloak client not available for instance %s", instanceName)
+			return nil, "", "", err
 		}
 	} else {
 		return nil, "", "", fmt.Errorf("client %s has no realmRef or clusterRealmRef", clientName)

--- a/internal/controller/keycloakusercredential_controller.go
+++ b/internal/controller/keycloakusercredential_controller.go
@@ -218,35 +218,9 @@ func (r *KeycloakUserCredentialReconciler) getKeycloakClient(ctx context.Context
 		return nil, "", fmt.Errorf("failed to parse realm definition: %w", err)
 	}
 
-	// Get the instance reference
-	instanceNamespace := realm.Namespace
-	if realm.Spec.InstanceRef.Namespace != nil {
-		instanceNamespace = *realm.Spec.InstanceRef.Namespace
-	}
-
-	instanceName := types.NamespacedName{
-		Name:      realm.Spec.InstanceRef.Name,
-		Namespace: instanceNamespace,
-	}
-
-	instance := &keycloakv1beta1.KeycloakInstance{}
-	if err := r.Get(ctx, instanceName, instance); err != nil {
-		return nil, "", fmt.Errorf("failed to get KeycloakInstance: %w", err)
-	}
-
-	if !instance.Status.Ready {
-		return nil, "", fmt.Errorf("KeycloakInstance %s is not ready", instance.Name)
-	}
-
-	// Get the Keycloak client
-	cfg, err := GetKeycloakConfigFromInstance(ctx, r.Client, instance)
+	kc, err := GetKeycloakClientFromRealmInstance(ctx, r.Client, r.ClientManager, realm)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to get Keycloak config from KeycloakInstance %s: %w", instanceName, err)
-	}
-
-	kc := r.ClientManager.GetOrCreateClient(instanceName.String(), cfg)
-	if kc == nil {
-		return nil, "", fmt.Errorf("failed to get Keycloak client")
+		return nil, "", err
 	}
 
 	return kc, realmDef.Realm, nil

--- a/test/e2e/realm_test.go
+++ b/test/e2e/realm_test.go
@@ -370,6 +370,124 @@ func TestKeycloakRealmE2E(t *testing.T) {
 		t.Logf("Realm correctly failed with missing key, message: %s", updated.Status.Message)
 	})
 
+	t.Run("RealmWithClusterInstanceRef", func(t *testing.T) {
+		clusterInstanceName := getOrCreateClusterInstance(t)
+		realmName := fmt.Sprintf("realm-cluster-ref-%d", time.Now().UnixNano())
+
+		realm := &keycloakv1beta1.KeycloakRealm{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      realmName,
+				Namespace: testNamespace,
+			},
+			Spec: keycloakv1beta1.KeycloakRealmSpec{
+				ClusterInstanceRef: &keycloakv1beta1.ClusterResourceRef{
+					Name: clusterInstanceName,
+				},
+				Definition: rawJSON(fmt.Sprintf(`{
+					"realm": "%s",
+					"displayName": "Cluster Instance Realm",
+					"enabled": true
+				}`, realmName)),
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, realm))
+		t.Cleanup(func() {
+			k8sClient.Delete(ctx, realm)
+		})
+
+		err := wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+			updated := &keycloakv1beta1.KeycloakRealm{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      realm.Name,
+				Namespace: realm.Namespace,
+			}, updated); err != nil {
+				return false, nil
+			}
+			return updated.Status.Ready, nil
+		})
+		require.NoError(t, err, "KeycloakRealm with clusterInstanceRef did not become ready")
+
+		updated := &keycloakv1beta1.KeycloakRealm{}
+		require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{
+			Name:      realm.Name,
+			Namespace: realm.Namespace,
+		}, updated))
+		require.NotEmpty(t, updated.Status.ResourcePath)
+		require.NotNil(t, updated.Status.Instance)
+		require.Equal(t, clusterInstanceName, updated.Status.Instance.ClusterInstanceRef,
+			"Status should reference the cluster instance")
+		t.Logf("KeycloakRealm %s with clusterInstanceRef is ready", realmName)
+	})
+
+	t.Run("RealmWithInvalidClusterInstanceRef", func(t *testing.T) {
+		realmName := fmt.Sprintf("realm-bad-cluster-ref-%d", time.Now().UnixNano())
+
+		realm := &keycloakv1beta1.KeycloakRealm{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      realmName,
+				Namespace: testNamespace,
+			},
+			Spec: keycloakv1beta1.KeycloakRealmSpec{
+				ClusterInstanceRef: &keycloakv1beta1.ClusterResourceRef{
+					Name: "nonexistent-cluster-instance",
+				},
+				Definition: rawJSON(fmt.Sprintf(`{
+					"realm": "%s",
+					"enabled": true
+				}`, realmName)),
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, realm))
+		t.Cleanup(func() {
+			k8sClient.Delete(ctx, realm)
+		})
+
+		time.Sleep(5 * time.Second)
+		updated := &keycloakv1beta1.KeycloakRealm{}
+		err := k8sClient.Get(ctx, types.NamespacedName{
+			Name:      realmName,
+			Namespace: testNamespace,
+		}, updated)
+		require.NoError(t, err)
+		require.False(t, updated.Status.Ready,
+			"Realm with nonexistent clusterInstanceRef should not be ready")
+		require.Contains(t, updated.Status.Message, "ClusterKeycloakInstance")
+		t.Logf("Realm correctly failed with invalid clusterInstanceRef, message: %s", updated.Status.Message)
+	})
+
+	t.Run("RealmWithNoInstanceRef", func(t *testing.T) {
+		realmName := fmt.Sprintf("realm-no-ref-%d", time.Now().UnixNano())
+
+		realm := &keycloakv1beta1.KeycloakRealm{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      realmName,
+				Namespace: testNamespace,
+			},
+			Spec: keycloakv1beta1.KeycloakRealmSpec{
+				Definition: rawJSON(fmt.Sprintf(`{
+					"realm": "%s",
+					"enabled": true
+				}`, realmName)),
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, realm))
+		t.Cleanup(func() {
+			k8sClient.Delete(ctx, realm)
+		})
+
+		time.Sleep(5 * time.Second)
+		updated := &keycloakv1beta1.KeycloakRealm{}
+		err := k8sClient.Get(ctx, types.NamespacedName{
+			Name:      realmName,
+			Namespace: testNamespace,
+		}, updated)
+		require.NoError(t, err)
+		require.False(t, updated.Status.Ready,
+			"Realm with neither instanceRef nor clusterInstanceRef should not be ready")
+		require.Contains(t, updated.Status.Message, "either instanceRef or clusterInstanceRef must be specified")
+		t.Logf("Realm correctly failed with no instance ref, message: %s", updated.Status.Message)
+	})
+
 	t.Run("ReconcileAfterManualDeletion", func(t *testing.T) {
 		// Skip if not running in-cluster or without port-forward
 		if !canConnectToKeycloak() {


### PR DESCRIPTION
KeycloakRealm supports both instanceRef and clusterInstanceRef, but controllers assumed instanceRef was always set. When a namespaced KeycloakRealm referenced a ClusterKeycloakInstance, the operator panicked with a nil pointer dereference.

Closes #48 