### PR TITLE
feat: support defaultClientScopes and optionalClientScopes on KeycloakClient

### DIFF
--- a/config/samples/keycloak_v1beta1_keycloakclient.yaml
+++ b/config/samples/keycloak_v1beta1_keycloakclient.yaml
@@ -21,6 +21,17 @@ spec:
       - "+"
     attributes:
       post.logout.redirect.uris: "+"
+    # Control which client scopes are assigned to this client.
+    # Omit these fields entirely to keep Keycloak's defaults.
+    # Set to an explicit list to enforce exactly those scopes.
+    # Set to [] to remove all scopes of that type.
+    defaultClientScopes:
+      - openid
+      - profile
+      - email
+    optionalClientScopes:
+      - phone
+      - address
   clientSecretRef:
     name: example-client-secret
     clientIdKey: client-id

--- a/internal/controller/keycloak_config.go
+++ b/internal/controller/keycloak_config.go
@@ -289,6 +289,27 @@ func mergeIDPConfig(definition json.RawMessage, secretData map[string]string) js
 	return result
 }
 
+// removeFieldFromDefinition removes a field from a JSON definition.
+// If the field doesn't exist or the JSON is invalid, the original is returned unchanged.
+func removeFieldFromDefinition(definition json.RawMessage, field string) json.RawMessage {
+	var defMap map[string]interface{}
+	if err := json.Unmarshal(definition, &defMap); err != nil {
+		return definition
+	}
+
+	if _, ok := defMap[field]; !ok {
+		return definition
+	}
+
+	delete(defMap, field)
+
+	result, err := json.Marshal(defMap)
+	if err != nil {
+		return definition
+	}
+	return result
+}
+
 // setFieldInDefinition sets a field value in a JSON definition
 func setFieldInDefinition(definition json.RawMessage, field string, value interface{}) json.RawMessage {
 	// Parse the definition as a map

--- a/internal/controller/keycloak_config_test.go
+++ b/internal/controller/keycloak_config_test.go
@@ -352,6 +352,80 @@ func TestSetFieldInDefinition(t *testing.T) {
 	}
 }
 
+func TestRemoveFieldFromDefinition(t *testing.T) {
+	tests := []struct {
+		name       string
+		definition json.RawMessage
+		field      string
+		want       string
+		wantSame   bool
+	}{
+		{
+			name:       "removes existing field",
+			definition: json.RawMessage(`{"clientId":"test","defaultClientScopes":["openid"]}`),
+			field:      "defaultClientScopes",
+			want:       `{"clientId":"test"}`,
+		},
+		{
+			name:       "no-op when field does not exist",
+			definition: json.RawMessage(`{"clientId":"test"}`),
+			field:      "defaultClientScopes",
+			wantSame:   true,
+		},
+		{
+			name:       "removes field leaving other fields intact",
+			definition: json.RawMessage(`{"a":"1","b":"2","c":"3"}`),
+			field:      "b",
+			want:       `{"a":"1","c":"3"}`,
+		},
+		{
+			name:       "invalid JSON returns original",
+			definition: json.RawMessage(`{invalid`),
+			field:      "foo",
+			wantSame:   true,
+		},
+		{
+			name:       "removes field from object with single field",
+			definition: json.RawMessage(`{"defaultClientScopes":["openid"]}`),
+			field:      "defaultClientScopes",
+			want:       `{}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := removeFieldFromDefinition(tt.definition, tt.field)
+
+			if tt.wantSame {
+				if string(got) != string(tt.definition) {
+					t.Errorf("expected original to be returned, got %s", string(got))
+				}
+				return
+			}
+
+			var gotMap, wantMap map[string]interface{}
+			if err := json.Unmarshal(got, &gotMap); err != nil {
+				t.Fatalf("failed to parse result: %v", err)
+			}
+			if err := json.Unmarshal([]byte(tt.want), &wantMap); err != nil {
+				t.Fatalf("failed to parse expected: %v", err)
+			}
+
+			if len(gotMap) != len(wantMap) {
+				t.Errorf("map length mismatch: got %d, want %d\ngot: %s\nwant: %s", len(gotMap), len(wantMap), string(got), tt.want)
+			}
+			for k, v := range wantMap {
+				if gotMap[k] != v {
+					t.Errorf("field %q: got %v, want %v", k, gotMap[k], v)
+				}
+			}
+			if _, exists := gotMap[tt.field]; exists {
+				t.Errorf("field %q should have been removed", tt.field)
+			}
+		})
+	}
+}
+
 func TestResolveFlowBindingAliases(t *testing.T) {
 	ctx := context.Background()
 	realmName := "test-realm"

--- a/internal/controller/keycloakclient_controller.go
+++ b/internal/controller/keycloakclient_controller.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -143,6 +144,14 @@ func (r *KeycloakClientReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 	}
 
+	// Extract client scope assignments before sending to Keycloak.
+	// Keycloak's client REST API ignores these fields — they require dedicated
+	// scope-assignment endpoints, which we call after create/update.
+	desiredDefaultScopes, hasDefaultScopes := extractStringSliceFromDefinition(definition, "defaultClientScopes")
+	desiredOptionalScopes, hasOptionalScopes := extractStringSliceFromDefinition(definition, "optionalClientScopes")
+	definition = removeFieldFromDefinition(definition, "defaultClientScopes")
+	definition = removeFieldFromDefinition(definition, "optionalClientScopes")
+
 	// Resolve authentication flow binding aliases to UUIDs
 	definition, err = resolveFlowBindingAliases(ctx, kc, realmName, definition)
 	if err != nil {
@@ -174,6 +183,14 @@ func (r *KeycloakClientReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			return r.updateStatus(ctx, kcClient, false, "UpdateFailed", fmt.Sprintf("Failed to update client: %v", err), clientUUID, instanceRef, realmRef)
 		}
 		log.Info("client updated successfully", "clientId", clientDef.ClientID)
+	}
+
+	// Sync default/optional client scope assignments
+	if err := r.syncClientScopes(ctx, kc, realmName, clientUUID,
+		desiredDefaultScopes, hasDefaultScopes,
+		desiredOptionalScopes, hasOptionalScopes); err != nil {
+		RecordError(controllerName, "scope_sync_error")
+		return r.updateStatus(ctx, kcClient, false, "ScopeSyncFailed", fmt.Sprintf("Failed to sync client scopes: %v", err), clientUUID, instanceRef, realmRef)
 	}
 
 	// Handle client secret sync - only if secretNeedsCreation (no pre-existing secret)
@@ -431,6 +448,131 @@ func (r *KeycloakClientReconciler) syncClientSecret(ctx context.Context, kcClien
 	})
 
 	return err
+}
+
+// syncClientScopes reconciles the default and optional client scope assignments
+// for a Keycloak client. It only acts when the corresponding field was explicitly
+// present in the definition JSON (even an empty array means "remove all").
+// If the field was absent, the operator leaves Keycloak's assignments untouched.
+func (r *KeycloakClientReconciler) syncClientScopes(
+	ctx context.Context, kc *keycloak.Client, realmName, clientUUID string,
+	desiredDefault []string, hasDefault bool,
+	desiredOptional []string, hasOptional bool,
+) error {
+	log := log.FromContext(ctx)
+
+	if !hasDefault && !hasOptional {
+		return nil
+	}
+
+	allScopes, err := kc.GetClientScopes(ctx, realmName)
+	if err != nil {
+		return fmt.Errorf("failed to list realm client scopes: %w", err)
+	}
+	scopeNameToID := make(map[string]string, len(allScopes))
+	for _, s := range allScopes {
+		if s.Name != nil && s.ID != nil {
+			scopeNameToID[*s.Name] = *s.ID
+		}
+	}
+
+	if hasDefault {
+		if err := r.reconcileScopeAssignments(ctx, log, kc, realmName, clientUUID, "default", desiredDefault, scopeNameToID,
+			kc.GetClientDefaultScopes, kc.AddClientDefaultScope, kc.RemoveClientDefaultScope); err != nil {
+			return fmt.Errorf("failed to sync default client scopes: %w", err)
+		}
+	}
+
+	if hasOptional {
+		if err := r.reconcileScopeAssignments(ctx, log, kc, realmName, clientUUID, "optional", desiredOptional, scopeNameToID,
+			kc.GetClientOptionalScopes, kc.AddClientOptionalScope, kc.RemoveClientOptionalScope); err != nil {
+			return fmt.Errorf("failed to sync optional client scopes: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (r *KeycloakClientReconciler) reconcileScopeAssignments(
+	ctx context.Context,
+	log logr.Logger,
+	kc *keycloak.Client,
+	realmName, clientUUID, scopeType string,
+	desiredNames []string,
+	scopeNameToID map[string]string,
+	getCurrent func(ctx context.Context, realm, clientUUID string) ([]keycloak.ClientScopeRepresentation, error),
+	addScope func(ctx context.Context, realm, clientUUID, scopeID string) error,
+	removeScope func(ctx context.Context, realm, clientUUID, scopeID string) error,
+) error {
+	current, err := getCurrent(ctx, realmName, clientUUID)
+	if err != nil {
+		return fmt.Errorf("failed to get current %s scopes: %w", scopeType, err)
+	}
+
+	currentByName := make(map[string]string, len(current))
+	for _, s := range current {
+		if s.Name != nil && s.ID != nil {
+			currentByName[*s.Name] = *s.ID
+		}
+	}
+
+	desiredSet := make(map[string]struct{}, len(desiredNames))
+	for _, name := range desiredNames {
+		desiredSet[name] = struct{}{}
+	}
+
+	// Remove scopes not in the desired list
+	for name, id := range currentByName {
+		if _, wanted := desiredSet[name]; !wanted {
+			log.Info("removing "+scopeType+" client scope", "scope", name, "clientUUID", clientUUID)
+			if err := removeScope(ctx, realmName, clientUUID, id); err != nil {
+				return fmt.Errorf("failed to remove %s scope %q: %w", scopeType, name, err)
+			}
+		}
+	}
+
+	// Add scopes that are desired but not yet assigned
+	for _, name := range desiredNames {
+		if _, exists := currentByName[name]; exists {
+			continue
+		}
+		id, ok := scopeNameToID[name]
+		if !ok {
+			return fmt.Errorf("%s scope %q does not exist in realm %q", scopeType, name, realmName)
+		}
+		log.Info("adding "+scopeType+" client scope", "scope", name, "clientUUID", clientUUID)
+		if err := addScope(ctx, realmName, clientUUID, id); err != nil {
+			return fmt.Errorf("failed to add %s scope %q: %w", scopeType, name, err)
+		}
+	}
+
+	return nil
+}
+
+// extractStringSliceFromDefinition extracts a string slice field from the
+// definition JSON. It returns the slice and a boolean indicating whether the
+// field was present in the JSON (an explicit null or missing key → false).
+func extractStringSliceFromDefinition(definition []byte, field string) ([]string, bool) {
+	var defMap map[string]json.RawMessage
+	if err := json.Unmarshal(definition, &defMap); err != nil {
+		return nil, false
+	}
+
+	raw, exists := defMap[field]
+	if !exists {
+		return nil, false
+	}
+
+	// Explicit null in JSON
+	if string(raw) == "null" {
+		return nil, false
+	}
+
+	var values []string
+	if err := json.Unmarshal(raw, &values); err != nil {
+		return nil, false
+	}
+	return values, true
 }
 
 func (r *KeycloakClientReconciler) deleteClient(ctx context.Context, kcClient *keycloakv1beta1.KeycloakClient) error {

--- a/internal/controller/keycloakclient_scopes_test.go
+++ b/internal/controller/keycloakclient_scopes_test.go
@@ -1,0 +1,293 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/go-logr/logr"
+
+	"github.com/Hostzero-GmbH/keycloak-operator/internal/keycloak"
+)
+
+func TestExtractStringSliceFromDefinition(t *testing.T) {
+	tests := []struct {
+		name       string
+		definition string
+		field      string
+		wantValues []string
+		wantExists bool
+	}{
+		{
+			name:       "field present with values",
+			definition: `{"defaultClientScopes":["openid","email","profile"]}`,
+			field:      "defaultClientScopes",
+			wantValues: []string{"openid", "email", "profile"},
+			wantExists: true,
+		},
+		{
+			name:       "field present as empty array",
+			definition: `{"defaultClientScopes":[]}`,
+			field:      "defaultClientScopes",
+			wantValues: []string{},
+			wantExists: true,
+		},
+		{
+			name:       "field absent",
+			definition: `{"clientId":"my-app"}`,
+			field:      "defaultClientScopes",
+			wantValues: nil,
+			wantExists: false,
+		},
+		{
+			name:       "field is null",
+			definition: `{"defaultClientScopes":null}`,
+			field:      "defaultClientScopes",
+			wantValues: nil,
+			wantExists: false,
+		},
+		{
+			name:       "invalid JSON",
+			definition: `{invalid`,
+			field:      "defaultClientScopes",
+			wantValues: nil,
+			wantExists: false,
+		},
+		{
+			name:       "field is not an array",
+			definition: `{"defaultClientScopes":"not-an-array"}`,
+			field:      "defaultClientScopes",
+			wantValues: nil,
+			wantExists: false,
+		},
+		{
+			name:       "optionalClientScopes with values",
+			definition: `{"optionalClientScopes":["phone","address"]}`,
+			field:      "optionalClientScopes",
+			wantValues: []string{"phone", "address"},
+			wantExists: true,
+		},
+		{
+			name:       "both fields present extracts correct one",
+			definition: `{"defaultClientScopes":["openid"],"optionalClientScopes":["phone"]}`,
+			field:      "defaultClientScopes",
+			wantValues: []string{"openid"},
+			wantExists: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, exists := extractStringSliceFromDefinition([]byte(tt.definition), tt.field)
+			if exists != tt.wantExists {
+				t.Errorf("exists: got %v, want %v", exists, tt.wantExists)
+			}
+			if tt.wantValues == nil {
+				if values != nil {
+					t.Errorf("values: got %v, want nil", values)
+				}
+			} else {
+				if len(values) != len(tt.wantValues) {
+					t.Fatalf("values length: got %d, want %d", len(values), len(tt.wantValues))
+				}
+				for i, v := range values {
+					if v != tt.wantValues[i] {
+						t.Errorf("values[%d]: got %q, want %q", i, v, tt.wantValues[i])
+					}
+				}
+			}
+		})
+	}
+}
+
+type scopeAction struct {
+	action string // "add" or "remove"
+	name   string
+}
+
+func TestReconcileScopeAssignments(t *testing.T) {
+	ctx := context.Background()
+	log := logr.Discard()
+	r := &KeycloakClientReconciler{}
+
+	realmScopes := map[string]string{
+		"openid":  "id-openid",
+		"email":   "id-email",
+		"profile": "id-profile",
+		"phone":   "id-phone",
+		"address": "id-address",
+		"roles":   "id-roles",
+	}
+
+	tests := []struct {
+		name        string
+		current     []keycloak.ClientScopeRepresentation
+		desired     []string
+		wantActions []scopeAction
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "no changes needed when current matches desired",
+			current: []keycloak.ClientScopeRepresentation{
+				{ID: ptr("id-openid"), Name: ptr("openid")},
+				{ID: ptr("id-email"), Name: ptr("email")},
+			},
+			desired:     []string{"openid", "email"},
+			wantActions: nil,
+		},
+		{
+			name: "adds missing scopes",
+			current: []keycloak.ClientScopeRepresentation{
+				{ID: ptr("id-openid"), Name: ptr("openid")},
+			},
+			desired: []string{"openid", "email", "profile"},
+			wantActions: []scopeAction{
+				{action: "add", name: "email"},
+				{action: "add", name: "profile"},
+			},
+		},
+		{
+			name: "removes extra scopes",
+			current: []keycloak.ClientScopeRepresentation{
+				{ID: ptr("id-openid"), Name: ptr("openid")},
+				{ID: ptr("id-email"), Name: ptr("email")},
+				{ID: ptr("id-phone"), Name: ptr("phone")},
+			},
+			desired: []string{"openid"},
+			wantActions: []scopeAction{
+				{action: "remove", name: "email"},
+				{action: "remove", name: "phone"},
+			},
+		},
+		{
+			name: "removes all when desired is empty",
+			current: []keycloak.ClientScopeRepresentation{
+				{ID: ptr("id-openid"), Name: ptr("openid")},
+				{ID: ptr("id-email"), Name: ptr("email")},
+			},
+			desired: []string{},
+			wantActions: []scopeAction{
+				{action: "remove", name: "openid"},
+				{action: "remove", name: "email"},
+			},
+		},
+		{
+			name:    "adds all when current is empty",
+			current: []keycloak.ClientScopeRepresentation{},
+			desired: []string{"openid", "email"},
+			wantActions: []scopeAction{
+				{action: "add", name: "openid"},
+				{action: "add", name: "email"},
+			},
+		},
+		{
+			name: "mixed add and remove",
+			current: []keycloak.ClientScopeRepresentation{
+				{ID: ptr("id-email"), Name: ptr("email")},
+				{ID: ptr("id-phone"), Name: ptr("phone")},
+			},
+			desired: []string{"email", "profile", "roles"},
+			wantActions: []scopeAction{
+				{action: "remove", name: "phone"},
+				{action: "add", name: "profile"},
+				{action: "add", name: "roles"},
+			},
+		},
+		{
+			name:        "error when desired scope does not exist in realm",
+			current:     []keycloak.ClientScopeRepresentation{},
+			desired:     []string{"nonexistent-scope"},
+			wantErr:     true,
+			errContains: "does not exist in realm",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var actions []scopeAction
+
+			getCurrent := func(_ context.Context, _, _ string) ([]keycloak.ClientScopeRepresentation, error) {
+				return tt.current, nil
+			}
+			addScope := func(_ context.Context, _, _, scopeID string) error {
+				for name, id := range realmScopes {
+					if id == scopeID {
+						actions = append(actions, scopeAction{action: "add", name: name})
+						return nil
+					}
+				}
+				return fmt.Errorf("unknown scope ID: %s", scopeID)
+			}
+			removeScope := func(_ context.Context, _, _, scopeID string) error {
+				for name, id := range realmScopes {
+					if id == scopeID {
+						actions = append(actions, scopeAction{action: "remove", name: name})
+						return nil
+					}
+				}
+				return fmt.Errorf("unknown scope ID: %s", scopeID)
+			}
+
+			err := r.reconcileScopeAssignments(ctx, log, nil, "test-realm", "client-uuid", "default",
+				tt.desired, realmScopes, getCurrent, addScope, removeScope)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.errContains != "" && !containsSubstring(err.Error(), tt.errContains) {
+					t.Errorf("error %q should contain %q", err.Error(), tt.errContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tt.wantActions == nil {
+				if len(actions) != 0 {
+					t.Errorf("expected no actions, got %v", actions)
+				}
+				return
+			}
+
+			// Build sets for comparison (order of removes/adds may vary due to map iteration)
+			wantSet := make(map[scopeAction]bool)
+			for _, a := range tt.wantActions {
+				wantSet[a] = true
+			}
+			gotSet := make(map[scopeAction]bool)
+			for _, a := range actions {
+				gotSet[a] = true
+			}
+
+			if len(gotSet) != len(wantSet) {
+				t.Errorf("actions count mismatch: got %d, want %d\ngot:  %v\nwant: %v", len(gotSet), len(wantSet), actions, tt.wantActions)
+			}
+			for a := range wantSet {
+				if !gotSet[a] {
+					t.Errorf("missing action: %v", a)
+				}
+			}
+			for a := range gotSet {
+				if !wantSet[a] {
+					t.Errorf("unexpected action: %v", a)
+				}
+			}
+		})
+	}
+}
+
+func ptr(s string) *string {
+	return &s
+}
+
+func containsSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/keycloak/client.go
+++ b/internal/keycloak/client.go
@@ -677,6 +677,48 @@ func (c *Client) DeleteClientScope(ctx context.Context, realmName, scopeID strin
 }
 
 // ============================================================================
+// Client Scope Assignment Operations (per-client)
+// ============================================================================
+
+// GetClientDefaultScopes gets the default client scopes assigned to a client
+func (c *Client) GetClientDefaultScopes(ctx context.Context, realmName, clientUUID string) ([]ClientScopeRepresentation, error) {
+	var scopes []ClientScopeRepresentation
+	if err := c.List(ctx, "/admin/realms/"+url.PathEscape(realmName)+"/clients/"+url.PathEscape(clientUUID)+"/default-client-scopes", nil, &scopes); err != nil {
+		return nil, err
+	}
+	return scopes, nil
+}
+
+// AddClientDefaultScope adds a default client scope to a client
+func (c *Client) AddClientDefaultScope(ctx context.Context, realmName, clientUUID, scopeID string) error {
+	return c.Update(ctx, "/admin/realms/"+url.PathEscape(realmName)+"/clients/"+url.PathEscape(clientUUID)+"/default-client-scopes/"+url.PathEscape(scopeID), nil)
+}
+
+// RemoveClientDefaultScope removes a default client scope from a client
+func (c *Client) RemoveClientDefaultScope(ctx context.Context, realmName, clientUUID, scopeID string) error {
+	return c.Delete(ctx, "/admin/realms/"+url.PathEscape(realmName)+"/clients/"+url.PathEscape(clientUUID)+"/default-client-scopes/"+url.PathEscape(scopeID))
+}
+
+// GetClientOptionalScopes gets the optional client scopes assigned to a client
+func (c *Client) GetClientOptionalScopes(ctx context.Context, realmName, clientUUID string) ([]ClientScopeRepresentation, error) {
+	var scopes []ClientScopeRepresentation
+	if err := c.List(ctx, "/admin/realms/"+url.PathEscape(realmName)+"/clients/"+url.PathEscape(clientUUID)+"/optional-client-scopes", nil, &scopes); err != nil {
+		return nil, err
+	}
+	return scopes, nil
+}
+
+// AddClientOptionalScope adds an optional client scope to a client
+func (c *Client) AddClientOptionalScope(ctx context.Context, realmName, clientUUID, scopeID string) error {
+	return c.Update(ctx, "/admin/realms/"+url.PathEscape(realmName)+"/clients/"+url.PathEscape(clientUUID)+"/optional-client-scopes/"+url.PathEscape(scopeID), nil)
+}
+
+// RemoveClientOptionalScope removes an optional client scope from a client
+func (c *Client) RemoveClientOptionalScope(ctx context.Context, realmName, clientUUID, scopeID string) error {
+	return c.Delete(ctx, "/admin/realms/"+url.PathEscape(realmName)+"/clients/"+url.PathEscape(clientUUID)+"/optional-client-scopes/"+url.PathEscape(scopeID))
+}
+
+// ============================================================================
 // Identity Provider Operations
 // ============================================================================
 

--- a/test/e2e/client_test.go
+++ b/test/e2e/client_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"sort"
 	"testing"
 	"time"
 
@@ -14,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	keycloakv1beta1 "github.com/Hostzero-GmbH/keycloak-operator/api/v1beta1"
+	"github.com/Hostzero-GmbH/keycloak-operator/internal/keycloak"
 )
 
 func TestKeycloakClientE2E(t *testing.T) {
@@ -703,6 +705,129 @@ func TestKeycloakClientE2E(t *testing.T) {
 		t.Log("Client was successfully reconciled (recreated) after manual deletion")
 	})
 
+	t.Run("ClientWithCustomScopes", func(t *testing.T) {
+		skipIfNoKeycloakAccess(t)
+
+		clientName := fmt.Sprintf("custom-scopes-client-%d", time.Now().UnixNano())
+		clientDef := rawJSON(fmt.Sprintf(`{
+			"clientId": "%s",
+			"name": "Custom Scopes Client",
+			"enabled": true,
+			"publicClient": true,
+			"standardFlowEnabled": true,
+			"defaultClientScopes": ["profile"],
+			"optionalClientScopes": ["phone"]
+		}`, clientName))
+		kcClient := &keycloakv1beta1.KeycloakClient{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clientName,
+				Namespace: testNamespace,
+			},
+			Spec: keycloakv1beta1.KeycloakClientSpec{
+				RealmRef:   &keycloakv1beta1.ResourceRef{Name: realmName},
+				Definition: &clientDef,
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, kcClient))
+		t.Cleanup(func() {
+			k8sClient.Delete(ctx, kcClient)
+		})
+
+		// Wait for client to be ready
+		var clientUUID string
+		err := wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+			updated := &keycloakv1beta1.KeycloakClient{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      kcClient.Name,
+				Namespace: kcClient.Namespace,
+			}, updated); err != nil {
+				return false, nil
+			}
+			if updated.Status.Ready {
+				clientUUID = updated.Status.ClientUUID
+				return true, nil
+			}
+			return false, nil
+		})
+		require.NoError(t, err, "Client with custom scopes did not become ready")
+
+		// Verify scopes via the Keycloak API
+		kc := getInternalKeycloakClient(t)
+
+		defaultScopes, err := kc.GetClientDefaultScopes(ctx, realmName, clientUUID)
+		require.NoError(t, err)
+		defaultNames := scopeNames(defaultScopes)
+		require.Equal(t, []string{"profile"}, defaultNames,
+			"default scopes should be exactly [profile]")
+
+		optionalScopes, err := kc.GetClientOptionalScopes(ctx, realmName, clientUUID)
+		require.NoError(t, err)
+		optionalNames := scopeNames(optionalScopes)
+		require.Equal(t, []string{"phone"}, optionalNames,
+			"optional scopes should be exactly [phone]")
+
+		t.Logf("Client %s has correct scopes: default=%v, optional=%v", clientName, defaultNames, optionalNames)
+	})
+
+	t.Run("ClientWithEmptyScopes", func(t *testing.T) {
+		skipIfNoKeycloakAccess(t)
+
+		clientName := fmt.Sprintf("empty-scopes-client-%d", time.Now().UnixNano())
+		clientDef := rawJSON(fmt.Sprintf(`{
+			"clientId": "%s",
+			"name": "Empty Scopes Client",
+			"enabled": true,
+			"publicClient": true,
+			"defaultClientScopes": [],
+			"optionalClientScopes": []
+		}`, clientName))
+		kcClient := &keycloakv1beta1.KeycloakClient{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clientName,
+				Namespace: testNamespace,
+			},
+			Spec: keycloakv1beta1.KeycloakClientSpec{
+				RealmRef:   &keycloakv1beta1.ResourceRef{Name: realmName},
+				Definition: &clientDef,
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, kcClient))
+		t.Cleanup(func() {
+			k8sClient.Delete(ctx, kcClient)
+		})
+
+		// Wait for client to be ready
+		var clientUUID string
+		err := wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+			updated := &keycloakv1beta1.KeycloakClient{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      kcClient.Name,
+				Namespace: kcClient.Namespace,
+			}, updated); err != nil {
+				return false, nil
+			}
+			if updated.Status.Ready {
+				clientUUID = updated.Status.ClientUUID
+				return true, nil
+			}
+			return false, nil
+		})
+		require.NoError(t, err, "Client with empty scopes did not become ready")
+
+		// Verify all scopes were removed
+		kc := getInternalKeycloakClient(t)
+
+		defaultScopes, err := kc.GetClientDefaultScopes(ctx, realmName, clientUUID)
+		require.NoError(t, err)
+		require.Empty(t, defaultScopes, "default scopes should be empty")
+
+		optionalScopes, err := kc.GetClientOptionalScopes(ctx, realmName, clientUUID)
+		require.NoError(t, err)
+		require.Empty(t, optionalScopes, "optional scopes should be empty")
+
+		t.Logf("Client %s correctly has no scopes assigned", clientName)
+	})
+
 	t.Run("ClientWithFlowBindingAlias", func(t *testing.T) {
 		// Create a client using browserFlowAlias instead of a UUID.
 		// "browser" is the default authentication flow alias in every Keycloak realm.
@@ -746,4 +871,15 @@ func TestKeycloakClientE2E(t *testing.T) {
 		require.NoError(t, err, "Client with browserFlowAlias did not become ready")
 		t.Logf("Client %s with browserFlowAlias is ready", clientName)
 	})
+}
+
+func scopeNames(scopes []keycloak.ClientScopeRepresentation) []string {
+	names := make([]string, 0, len(scopes))
+	for _, s := range scopes {
+		if s.Name != nil {
+			names = append(names, *s.Name)
+		}
+	}
+	sort.Strings(names)
+	return names
 }


### PR DESCRIPTION
Keycloak's client REST API ignores these fields in the request body - they require dedicated scope-assignment endpoints. The operator now extracts them from the definition, strips them before sending to Keycloak, and reconciles the assignments via the per-client scope APIs after create/update.

Resolves #51 