### PR TITLE
fix: use exact match for client lookup by clientId

### DIFF
--- a/internal/controller/keycloakrolemapping_controller.go
+++ b/internal/controller/keycloakrolemapping_controller.go
@@ -215,6 +215,7 @@ func (r *KeycloakRoleMappingReconciler) resolveRole(ctx context.Context, mapping
 				// Use clientID directly - need to look up the UUID
 				clients, err := kc.GetClients(ctx, realmName, map[string]string{
 					"clientId": *mapping.Spec.Role.ClientID,
+					"exact":    "true",
 				})
 				if err != nil || len(clients) == 0 {
 					return roleName, "client", "", fmt.Errorf("client %s not found", *mapping.Spec.Role.ClientID)

--- a/internal/keycloak/client.go
+++ b/internal/keycloak/client.go
@@ -419,11 +419,14 @@ func (c *Client) GetClients(ctx context.Context, realmName string, params map[st
 
 // GetClientByClientID finds a client by its clientId field
 func (c *Client) GetClientByClientID(ctx context.Context, realmName, clientID string) (*ClientRepresentation, error) {
-	clients, err := c.GetClients(ctx, realmName, map[string]string{"clientId": clientID})
+	clients, err := c.GetClients(ctx, realmName, map[string]string{"clientId": clientID, "exact": "true"})
 	if err != nil {
 		return nil, err
 	}
 	if len(clients) == 0 {
+		return nil, fmt.Errorf("client not found: %s", clientID)
+	}
+	if clients[0].ClientID == nil || *clients[0].ClientID != clientID {
 		return nil, fmt.Errorf("client not found: %s", clientID)
 	}
 	return &clients[0], nil


### PR DESCRIPTION
## Problem

`GetClientByClientID` and the rolemapping controller's direct `GetClients` call use substring matching when looking up clients by `clientId`. When two clients share a prefix (e.g. `app` and `app-admin`), the wrong client can be returned.

## Fix

- Add `"exact": "true"` to the query parameters in `GetClientByClientID` and in `keycloakrolemapping_controller.go`
- Add a defensive post-filter in `GetClientByClientID` to verify the returned client's `clientId` matches exactly

## Files changed

- `internal/keycloak/client.go` — `GetClientByClientID`
- `internal/controller/keycloakrolemapping_controller.go` — `resolveRole`