### PR TITLE
fix: add offset-based pagination for list helpers

### DIFF
--- a/internal/keycloak/client.go
+++ b/internal/keycloak/client.go
@@ -269,6 +269,33 @@ func (c *Client) List(ctx context.Context, path string, params map[string]string
 	return nil
 }
 
+// listAll retrieves all resources using offset-based pagination.
+// The Keycloak Admin API defaults to returning at most 100 results.
+// This helper pages through all results using the "first" and "max" query
+// parameters and returns the full list.
+func listAll[T any](ctx context.Context, c *Client, path string, params map[string]string) ([]T, error) {
+	const pageSize = 100
+	if params == nil {
+		params = make(map[string]string)
+	}
+
+	var all []T
+	for offset := 0; ; offset += pageSize {
+		params["first"] = fmt.Sprintf("%d", offset)
+		params["max"] = fmt.Sprintf("%d", pageSize)
+
+		var page []T
+		if err := c.List(ctx, path, params, &page); err != nil {
+			return nil, err
+		}
+		all = append(all, page...)
+		if len(page) < pageSize {
+			break
+		}
+	}
+	return all, nil
+}
+
 // Post performs a POST request (for non-CRUD operations)
 func (c *Client) Post(ctx context.Context, path string, body interface{}, result interface{}) error {
 	req, err := c.request(ctx)
@@ -410,11 +437,7 @@ func (c *Client) GetClient(ctx context.Context, realmName, clientID string) (*Cl
 
 // GetClients gets all clients in a realm with optional filtering
 func (c *Client) GetClients(ctx context.Context, realmName string, params map[string]string) ([]ClientRepresentation, error) {
-	var clients []ClientRepresentation
-	if err := c.List(ctx, "/admin/realms/"+url.PathEscape(realmName)+"/clients", params, &clients); err != nil {
-		return nil, err
-	}
-	return clients, nil
+	return listAll[ClientRepresentation](ctx, c, "/admin/realms/"+url.PathEscape(realmName)+"/clients", params)
 }
 
 // GetClientByClientID finds a client by its clientId field
@@ -507,11 +530,7 @@ func (c *Client) GetUser(ctx context.Context, realmName, userID string) (*UserRe
 
 // GetUsers gets users with optional filtering
 func (c *Client) GetUsers(ctx context.Context, realmName string, params map[string]string) ([]UserRepresentation, error) {
-	var users []UserRepresentation
-	if err := c.List(ctx, "/admin/realms/"+url.PathEscape(realmName)+"/users", params, &users); err != nil {
-		return nil, err
-	}
-	return users, nil
+	return listAll[UserRepresentation](ctx, c, "/admin/realms/"+url.PathEscape(realmName)+"/users", params)
 }
 
 // GetUserByUsername finds a user by username
@@ -585,11 +604,7 @@ func (c *Client) GetGroup(ctx context.Context, realmName, groupID string) (*Grou
 
 // GetGroups gets all groups in a realm
 func (c *Client) GetGroups(ctx context.Context, realmName string, params map[string]string) ([]GroupRepresentation, error) {
-	var groups []GroupRepresentation
-	if err := c.List(ctx, "/admin/realms/"+url.PathEscape(realmName)+"/groups", params, &groups); err != nil {
-		return nil, err
-	}
-	return groups, nil
+	return listAll[GroupRepresentation](ctx, c, "/admin/realms/"+url.PathEscape(realmName)+"/groups", params)
 }
 
 // GetGroupByName finds a group by name
@@ -1082,11 +1097,7 @@ type OrganizationDomain struct {
 
 // GetOrganizations gets all organizations in a realm
 func (c *Client) GetOrganizations(ctx context.Context, realmName string) ([]OrganizationRepresentation, error) {
-	var orgs []OrganizationRepresentation
-	if err := c.List(ctx, "/admin/realms/"+url.PathEscape(realmName)+"/organizations", nil, &orgs); err != nil {
-		return nil, err
-	}
-	return orgs, nil
+	return listAll[OrganizationRepresentation](ctx, c, "/admin/realms/"+url.PathEscape(realmName)+"/organizations", nil)
 }
 
 // GetOrganization gets an organization by ID
@@ -1321,11 +1332,7 @@ func (c *Client) GetIdentityProviderRaw(ctx context.Context, realmName, alias st
 
 // GetRealmRoles gets all realm roles
 func (c *Client) GetRealmRoles(ctx context.Context, realmName string) ([]RoleRepresentation, error) {
-	var roles []RoleRepresentation
-	if err := c.List(ctx, "/admin/realms/"+url.PathEscape(realmName)+"/roles", nil, &roles); err != nil {
-		return nil, err
-	}
-	return roles, nil
+	return listAll[RoleRepresentation](ctx, c, "/admin/realms/"+url.PathEscape(realmName)+"/roles", nil)
 }
 
 // GetRealmRolesRaw gets all realm roles as raw JSON

--- a/internal/keycloak/client_test.go
+++ b/internal/keycloak/client_test.go
@@ -1,0 +1,248 @@
+package keycloak
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeListServer is a minimal Keycloak Admin API stand-in that paginates a
+// fixed slice of items using the standard `first` and `max` query parameters.
+type fakeListServer struct {
+	itemCount int
+	requests  []map[string]string
+
+	// passthroughParams records all query params that were forwarded to the
+	// server on each request, so tests can verify caller-supplied filters
+	// (e.g. "search", "exact") are preserved across pages.
+	passthroughParams []map[string]string
+}
+
+func newFakeListServer(itemCount int) *fakeListServer {
+	return &fakeListServer{itemCount: itemCount}
+}
+
+func (f *fakeListServer) handler(t *testing.T) http.Handler {
+	t.Helper()
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/realms/master/protocol/openid-connect/token", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"test","expires_in":300,"token_type":"Bearer"}`))
+	})
+
+	mux.HandleFunc("/admin/realms/test/things", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+
+		recorded := map[string]string{}
+		for k, v := range q {
+			if len(v) > 0 {
+				recorded[k] = v[0]
+			}
+		}
+		f.passthroughParams = append(f.passthroughParams, recorded)
+
+		first, _ := strconv.Atoi(q.Get("first"))
+		max, _ := strconv.Atoi(q.Get("max"))
+		if max <= 0 {
+			max = 100
+		}
+
+		f.requests = append(f.requests, map[string]string{
+			"first": q.Get("first"),
+			"max":   q.Get("max"),
+		})
+
+		end := first + max
+		if end > f.itemCount {
+			end = f.itemCount
+		}
+		if first >= f.itemCount {
+			end = first
+		}
+
+		items := make([]map[string]any, 0, end-first)
+		for i := first; i < end; i++ {
+			items = append(items, map[string]any{"id": fmt.Sprintf("item-%d", i)})
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(items)
+	})
+
+	return mux
+}
+
+func newTestClient(t *testing.T, baseURL string) *Client {
+	t.Helper()
+	return NewClient(Config{
+		BaseURL:      baseURL,
+		Realm:        "master",
+		ClientID:     "admin-cli",
+		ClientSecret: "secret",
+	}, testr.New(t))
+}
+
+type thing struct {
+	ID string `json:"id"`
+}
+
+// TestListAll_SinglePage covers the common case where the entire result set
+// fits in one page. Exactly one HTTP request must be made.
+func TestListAll_SinglePage(t *testing.T) {
+	fake := newFakeListServer(42)
+	srv := httptest.NewServer(fake.handler(t))
+	t.Cleanup(srv.Close)
+
+	c := newTestClient(t, srv.URL)
+	got, err := listAll[thing](context.Background(), c, "/admin/realms/test/things", nil)
+	require.NoError(t, err)
+	assert.Len(t, got, 42)
+	assert.Len(t, fake.requests, 1, "expected exactly one request when result set is smaller than a page")
+	assert.Equal(t, "0", fake.requests[0]["first"])
+	assert.Equal(t, "100", fake.requests[0]["max"])
+}
+
+// TestListAll_EmptyResult covers the empty result set: exactly one request,
+// zero items, no panic on appending to a nil slice.
+func TestListAll_EmptyResult(t *testing.T) {
+	fake := newFakeListServer(0)
+	srv := httptest.NewServer(fake.handler(t))
+	t.Cleanup(srv.Close)
+
+	c := newTestClient(t, srv.URL)
+	got, err := listAll[thing](context.Background(), c, "/admin/realms/test/things", nil)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+	assert.Len(t, fake.requests, 1)
+}
+
+// TestListAll_MultiPage is the regression test for the bug this MR fixes.
+// Without the listAll helper the client returns at most 100 items because
+// that's the Keycloak Admin API default.
+func TestListAll_MultiPage(t *testing.T) {
+	fake := newFakeListServer(250)
+	srv := httptest.NewServer(fake.handler(t))
+	t.Cleanup(srv.Close)
+
+	c := newTestClient(t, srv.URL)
+	got, err := listAll[thing](context.Background(), c, "/admin/realms/test/things", nil)
+	require.NoError(t, err)
+
+	require.Len(t, got, 250)
+	for i, item := range got {
+		assert.Equal(t, fmt.Sprintf("item-%d", i), item.ID)
+	}
+
+	require.Len(t, fake.requests, 3, "expected 3 paginated requests (100 + 100 + 50)")
+	assert.Equal(t, "0", fake.requests[0]["first"])
+	assert.Equal(t, "100", fake.requests[1]["first"])
+	assert.Equal(t, "200", fake.requests[2]["first"])
+}
+
+// TestListAll_ExactPageBoundary covers the edge case where the total number of
+// items is an exact multiple of the page size. The helper has no way of
+// knowing the previous page was the last one (all pages are full), so it must
+// make one extra request and stop on the empty page.
+func TestListAll_ExactPageBoundary(t *testing.T) {
+	fake := newFakeListServer(200)
+	srv := httptest.NewServer(fake.handler(t))
+	t.Cleanup(srv.Close)
+
+	c := newTestClient(t, srv.URL)
+	got, err := listAll[thing](context.Background(), c, "/admin/realms/test/things", nil)
+	require.NoError(t, err)
+
+	assert.Len(t, got, 200)
+	assert.Len(t, fake.requests, 3, "expected 3 requests at exact page boundary (100 + 100 + 0)")
+}
+
+// TestListAll_PreservesCallerParams ensures caller-supplied query parameters
+// (such as `search`/`exact` used by GetGroupByName/GetUserByUsername) are
+// forwarded on every paginated request.
+func TestListAll_PreservesCallerParams(t *testing.T) {
+	fake := newFakeListServer(150)
+	srv := httptest.NewServer(fake.handler(t))
+	t.Cleanup(srv.Close)
+
+	c := newTestClient(t, srv.URL)
+	params := map[string]string{
+		"search": "foo",
+		"exact":  "true",
+	}
+	got, err := listAll[thing](context.Background(), c, "/admin/realms/test/things", params)
+	require.NoError(t, err)
+	assert.Len(t, got, 150)
+
+	require.Len(t, fake.passthroughParams, 2)
+	for i, p := range fake.passthroughParams {
+		assert.Equal(t, "foo", p["search"], "request %d lost the search param", i)
+		assert.Equal(t, "true", p["exact"], "request %d lost the exact param", i)
+	}
+}
+
+// TestListAll_ServerError surfaces upstream errors immediately instead of
+// looping forever on a failing endpoint.
+func TestListAll_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/realms/master/protocol/openid-connect/token" {
+			_, _ = w.Write([]byte(`{"access_token":"test","expires_in":300,"token_type":"Bearer"}`))
+			return
+		}
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := newTestClient(t, srv.URL)
+	_, err := listAll[thing](context.Background(), c, "/admin/realms/test/things", nil)
+	require.Error(t, err)
+}
+
+// TestGetClients_Paginated wires the production GetClients helper end to end
+// against the fake server to prove the public API actually returns more than
+// one Keycloak page worth of results.
+func TestGetClients_Paginated(t *testing.T) {
+	const total = 213
+	fake := &fakeListServer{itemCount: total}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/realms/master/protocol/openid-connect/token", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"access_token":"test","expires_in":300,"token_type":"Bearer"}`))
+	})
+	mux.HandleFunc("/admin/realms/test/clients", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		first, _ := strconv.Atoi(q.Get("first"))
+		max, _ := strconv.Atoi(q.Get("max"))
+		if max <= 0 {
+			max = 100
+		}
+		end := first + max
+		if end > fake.itemCount {
+			end = fake.itemCount
+		}
+		if first >= fake.itemCount {
+			end = first
+		}
+		items := make([]ClientRepresentation, 0, end-first)
+		for i := first; i < end; i++ {
+			id := fmt.Sprintf("client-%d", i)
+			items = append(items, ClientRepresentation{ID: &id, ClientID: &id})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(items)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	c := newTestClient(t, srv.URL)
+	clients, err := c.GetClients(context.Background(), "test", nil)
+	require.NoError(t, err)
+	assert.Len(t, clients, total, "GetClients must return the full result set across pages")
+}

--- a/test/e2e/list_pagination_test.go
+++ b/test/e2e/list_pagination_test.go
@@ -1,0 +1,143 @@
+package e2e
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestListPaginationE2E exercises the listAll[T] helper added in
+// fix/list-pagination against a real Keycloak instance. The Keycloak Admin
+// API caps every list response at 100 items by default, so before this fix
+// realms with more than 100 of any resource silently lost the rest. The
+// regression we are guarding against is GetClients/GetUsers/GetGroups/
+// GetRealmRoles returning at most 100 items.
+//
+// We bypass the operator and CRDs entirely here: we provision the resources
+// directly via the Keycloak Admin API, then call the production list helpers
+// and assert that we see *all* of them. Going through the operator would
+// require creating hundreds of CRs, which is an order of magnitude slower
+// and tests reconciler behavior, not the client pagination we care about.
+//
+// To keep the test cheap on CI we use the smallest count that still proves
+// pagination — one full page (100) plus a handful — for each resource type.
+func TestListPaginationE2E(t *testing.T) {
+	skipIfNoCluster(t)
+	skipIfNoKeycloakAccess(t)
+
+	const overflow = 5 // items in the 2nd page; total per type = 100 + overflow
+	const want = 100 + overflow
+
+	instanceName, instanceNS := getOrCreateInstance(t)
+	realmName := createTestRealm(t, instanceName, instanceNS, "pagination")
+	kc := getInternalKeycloakClient(t)
+
+	suffix := time.Now().UnixNano()
+
+	t.Run("Users", func(t *testing.T) {
+		prefix := fmt.Sprintf("page-user-%d-", suffix)
+		for i := 0; i < want; i++ {
+			name := fmt.Sprintf("%s%03d", prefix, i)
+			body := json.RawMessage(fmt.Sprintf(`{"username":%q,"enabled":true}`, name))
+			_, err := kc.CreateUser(ctx, realmName, body)
+			require.NoErrorf(t, err, "create user %s", name)
+		}
+
+		users, err := kc.GetUsers(ctx, realmName, nil)
+		require.NoError(t, err)
+		got := countMatching(len(users), func(i int) string {
+			return derefString(users[i].Username)
+		}, prefix)
+		assert.Equalf(t, want, got, "GetUsers must paginate past 100 (got %d, want %d)", got, want)
+	})
+
+	t.Run("Groups", func(t *testing.T) {
+		prefix := fmt.Sprintf("page-group-%d-", suffix)
+		for i := 0; i < want; i++ {
+			name := fmt.Sprintf("%s%03d", prefix, i)
+			body := json.RawMessage(fmt.Sprintf(`{"name":%q}`, name))
+			_, err := kc.CreateGroup(ctx, realmName, body)
+			require.NoErrorf(t, err, "create group %s", name)
+		}
+
+		groups, err := kc.GetGroups(ctx, realmName, nil)
+		require.NoError(t, err)
+		got := countMatching(len(groups), func(i int) string {
+			return derefString(groups[i].Name)
+		}, prefix)
+		assert.Equalf(t, want, got, "GetGroups must paginate past 100 (got %d, want %d)", got, want)
+	})
+
+	t.Run("RealmRoles", func(t *testing.T) {
+		prefix := fmt.Sprintf("page-role-%d-", suffix)
+		for i := 0; i < want; i++ {
+			name := fmt.Sprintf("%s%03d", prefix, i)
+			body := json.RawMessage(fmt.Sprintf(`{"name":%q}`, name))
+			_, err := kc.CreateRealmRole(ctx, realmName, body)
+			require.NoErrorf(t, err, "create role %s", name)
+		}
+
+		roles, err := kc.GetRealmRoles(ctx, realmName)
+		require.NoError(t, err)
+		got := countMatching(len(roles), func(i int) string {
+			return derefString(roles[i].Name)
+		}, prefix)
+		assert.Equalf(t, want, got, "GetRealmRoles must paginate past 100 (got %d, want %d)", got, want)
+	})
+
+	t.Run("Clients", func(t *testing.T) {
+		prefix := fmt.Sprintf("page-client-%d-", suffix)
+		for i := 0; i < want; i++ {
+			name := fmt.Sprintf("%s%03d", prefix, i)
+			body := json.RawMessage(fmt.Sprintf(`{"clientId":%q,"enabled":true,"protocol":"openid-connect"}`, name))
+			_, err := kc.CreateClient(ctx, realmName, body)
+			require.NoErrorf(t, err, "create client %s", name)
+		}
+
+		clients, err := kc.GetClients(ctx, realmName, nil)
+		require.NoError(t, err)
+		got := countMatching(len(clients), func(i int) string {
+			return derefString(clients[i].ClientID)
+		}, prefix)
+		assert.Equalf(t, want, got, "GetClients must paginate past 100 (got %d, want %d)", got, want)
+	})
+
+	// Cross-check with the underlying RawMessage list helpers (used by the
+	// exporter). These don't currently use listAll, so they're a useful
+	// reference: with stock Keycloak they should hit the 100-item cap. If
+	// this assumption ever changes (e.g. Keycloak's defaults change), we'll
+	// notice here.
+	t.Run("RawListsHit100Cap_DocumentingDefault", func(t *testing.T) {
+		raw, err := kc.GetUsersRaw(ctx, realmName, nil)
+		require.NoError(t, err)
+		// We pre-created 100+overflow users; the raw helper does not
+		// paginate, so it should still cap at 100.
+		assert.LessOrEqualf(t, len(raw), 100,
+			"GetUsersRaw is expected to hit Keycloak's default page cap; if this fails, "+
+				"either pagination was added to it (great — update this test) or Keycloak's "+
+				"defaults changed (got %d items)", len(raw))
+	})
+
+}
+
+func countMatching(n int, at func(int) string, prefix string) int {
+	c := 0
+	for i := 0; i < n; i++ {
+		if strings.HasPrefix(at(i), prefix) {
+			c++
+		}
+	}
+	return c
+}
+
+func derefString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}


### PR DESCRIPTION
## Problem

The Keycloak Admin API returns at most 100 results by default. `GetClients`, `GetUsers`, `GetGroups`, `GetRealmRoles`, and `GetOrganizations` all use the `List` helper without pagination, so realms with more than 100 resources of any type silently return truncated results.

## Fix

Add a generic `listAll[T]` helper that pages through all results using the `first` and `max` query parameters (page size 100, stops when a page returns fewer than 100 items). Wire all five list functions through it.

## Files changed

- `internal/keycloak/client.go` — new `listAll[T]` helper, refactored `GetClients`, `GetUsers`, `GetGroups`, `GetRealmRoles`, `GetOrganizations`