### PR TITLE
Fix nested group export and reconciliation on Keycloak 23+

### DIFF
--- a/internal/controller/keycloakgroup_controller.go
+++ b/internal/controller/keycloakgroup_controller.go
@@ -126,14 +126,26 @@ func (r *KeycloakGroupReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		parentGroupID = parentGroup.Status.GroupID
 	}
 
-	// Check if group exists by name
-	existingGroups, err := kc.GetGroups(ctx, realmName, map[string]string{
-		"search": groupDef.Name,
-	})
+	// Check if group exists by name. When a parent is set, scope the lookup to
+	// the parent's children — Keycloak 23+ no longer inlines subGroups in the
+	// realm-wide /groups response, so we cannot rely on a recursive walk.
 	var existingGroup *keycloak.GroupRepresentation
-	if err == nil {
-		// Search through groups (including nested) for exact name match
-		existingGroup = findGroupByNameInList(existingGroups, groupDef.Name, parentGroupID)
+	if parentGroupID != "" {
+		children, err := kc.GetGroupChildren(ctx, realmName, parentGroupID, map[string]string{
+			"search": groupDef.Name,
+			"exact":  "true",
+		})
+		if err == nil {
+			existingGroup = findTopLevelGroupByName(children, groupDef.Name)
+		}
+	} else {
+		existingGroups, err := kc.GetGroups(ctx, realmName, map[string]string{
+			"search": groupDef.Name,
+			"exact":  "true",
+		})
+		if err == nil {
+			existingGroup = findTopLevelGroupByName(existingGroups, groupDef.Name)
+		}
 	}
 
 	var groupID string
@@ -172,24 +184,16 @@ func (r *KeycloakGroupReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	return r.updateStatus(ctx, group, true, "Ready", "Group synchronized", groupID)
 }
 
-// findGroupByNameInList searches for a group by name in a list
-func findGroupByNameInList(groups []keycloak.GroupRepresentation, name string, parentID string) *keycloak.GroupRepresentation {
+// findTopLevelGroupByName returns the first group in the list whose name
+// matches exactly. The list is expected to already be scoped to the right
+// parent (either top-level or a specific parent's children); we deliberately
+// do not recurse into SubGroups, which would be incorrect across parents and
+// is empty anyway on Keycloak 23+.
+func findTopLevelGroupByName(groups []keycloak.GroupRepresentation, name string) *keycloak.GroupRepresentation {
 	for i := range groups {
 		g := &groups[i]
 		if g.Name != nil && *g.Name == name {
-			// If no parent specified, return top-level match
-			if parentID == "" {
-				return g
-			}
-			// With parent, check if group is within that parent's subgroups
-			// Note: We've already searched within the parent context
 			return g
-		}
-		// Search subgroups recursively
-		if len(g.SubGroups) > 0 {
-			if found := findGroupByNameInList(g.SubGroups, name, parentID); found != nil {
-				return found
-			}
 		}
 	}
 	return nil

--- a/internal/controller/keycloakgroup_controller_test.go
+++ b/internal/controller/keycloakgroup_controller_test.go
@@ -1,0 +1,31 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/Hostzero-GmbH/keycloak-operator/internal/keycloak"
+)
+
+// TestFindTopLevelGroupByName documents that the helper only matches against
+// the top-level entries of the supplied slice. Callers (the KeycloakGroup
+// reconciler) are expected to scope the slice to the right parent before
+// calling it. Recursing into SubGroups would be incorrect across parents and
+// is also unreliable on Keycloak 23+, where SubGroups is empty in the
+// realm-wide listing.
+func TestFindTopLevelGroupByName(t *testing.T) {
+	ptr := func(s string) *string { return &s }
+	groups := []keycloak.GroupRepresentation{
+		{Name: ptr("alpha")},
+		{Name: ptr("beta"), SubGroups: []keycloak.GroupRepresentation{{Name: ptr("nested")}}},
+	}
+
+	if got := findTopLevelGroupByName(groups, "beta"); got == nil || got.Name == nil || *got.Name != "beta" {
+		t.Errorf("findTopLevelGroupByName(beta) = %+v, want beta", got)
+	}
+	if got := findTopLevelGroupByName(groups, "missing"); got != nil {
+		t.Errorf("findTopLevelGroupByName(missing) = %+v, want nil", got)
+	}
+	if got := findTopLevelGroupByName(groups, "nested"); got != nil {
+		t.Errorf("findTopLevelGroupByName must not recurse into SubGroups, got %+v", got)
+	}
+}

--- a/internal/export/exporter.go
+++ b/internal/export/exporter.go
@@ -5,12 +5,17 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/go-logr/logr"
 
 	"github.com/Hostzero-GmbH/keycloak-operator/internal/keycloak"
 )
+
+// groupChildrenPageSize is the page size used when paging through
+// /admin/realms/{realm}/groups/{id}/children.
+const groupChildrenPageSize = 100
 
 // ExporterOptions configures the export behavior
 type ExporterOptions struct {
@@ -224,6 +229,15 @@ func (e *Exporter) exportClients(ctx context.Context) ([]ExportedResource, error
 	return resources, nil
 }
 
+// groupHeader captures the fields we need from a raw group response to
+// determine its identity and whether it has children to fetch.
+type groupHeader struct {
+	ID            string            `json:"id"`
+	Name          string            `json:"name"`
+	SubGroupCount int               `json:"subGroupCount"`
+	SubGroups     []json.RawMessage `json:"subGroups"`
+}
+
 func (e *Exporter) exportGroups(ctx context.Context) ([]ExportedResource, error) {
 	rawGroups, err := e.client.GetGroupsRaw(ctx, e.opts.Realm)
 	if err != nil {
@@ -232,12 +246,7 @@ func (e *Exporter) exportGroups(ctx context.Context) ([]ExportedResource, error)
 
 	var resources []ExportedResource
 	for _, raw := range rawGroups {
-		// Parse to get group info
-		var group struct {
-			ID        string            `json:"id"`
-			Name      string            `json:"name"`
-			SubGroups []json.RawMessage `json:"subGroups"`
-		}
+		var group groupHeader
 		if err := json.Unmarshal(raw, &group); err != nil {
 			continue
 		}
@@ -249,11 +258,10 @@ func (e *Exporter) exportGroups(ctx context.Context) ([]ExportedResource, error)
 		}
 		resources = append(resources, resource)
 
-		// Recursively export subgroups
-		subgroups := e.exportSubGroups(group.SubGroups, group.Name)
+		children := e.resolveGroupChildren(ctx, group)
+		subgroups := e.exportSubGroups(ctx, children, group.Name)
 		resources = append(resources, subgroups...)
 
-		// Export role mappings for this group
 		if e.filter.ShouldIncludeType(ResourceTypeRoleMappings) {
 			mappings, err := e.exportGroupRoleMappings(ctx, group.ID, group.Name)
 			if err != nil {
@@ -267,13 +275,10 @@ func (e *Exporter) exportGroups(ctx context.Context) ([]ExportedResource, error)
 	return resources, nil
 }
 
-func (e *Exporter) exportSubGroups(subgroups []json.RawMessage, parentName string) []ExportedResource {
+func (e *Exporter) exportSubGroups(ctx context.Context, subgroups []json.RawMessage, parentName string) []ExportedResource {
 	var resources []ExportedResource
 	for _, raw := range subgroups {
-		var group struct {
-			Name      string            `json:"name"`
-			SubGroups []json.RawMessage `json:"subGroups"`
-		}
+		var group groupHeader
 		if err := json.Unmarshal(raw, &group); err != nil {
 			continue
 		}
@@ -285,12 +290,62 @@ func (e *Exporter) exportSubGroups(subgroups []json.RawMessage, parentName strin
 		}
 		resources = append(resources, resource)
 
-		// Recursively export subgroups
 		fullPath := parentName + "/" + group.Name
-		subres := e.exportSubGroups(group.SubGroups, fullPath)
+
+		if e.filter.ShouldIncludeType(ResourceTypeRoleMappings) && group.ID != "" {
+			mappings, err := e.exportGroupRoleMappings(ctx, group.ID, fullPath)
+			if err != nil {
+				e.log.Error(err, "Failed to export role mappings for subgroup", "name", group.Name, "parent", parentName)
+			} else {
+				resources = append(resources, mappings...)
+			}
+		}
+
+		children := e.resolveGroupChildren(ctx, group)
+		subres := e.exportSubGroups(ctx, children, fullPath)
 		resources = append(resources, subres...)
 	}
 	return resources
+}
+
+// resolveGroupChildren returns the direct children of a group. It prefers the
+// inline subGroups field (legacy Keycloak < 23) and falls back to the
+// /groups/{id}/children endpoint when the listing returned an empty subGroups
+// array but a non-zero subGroupCount (Keycloak 23+).
+func (e *Exporter) resolveGroupChildren(ctx context.Context, group groupHeader) []json.RawMessage {
+	if len(group.SubGroups) > 0 {
+		return group.SubGroups
+	}
+	if group.SubGroupCount <= 0 || group.ID == "" {
+		return nil
+	}
+
+	children, err := e.listGroupChildren(ctx, group.ID)
+	if err != nil {
+		e.log.Error(err, "Failed to list group children", "name", group.Name, "id", group.ID)
+		return nil
+	}
+	return children
+}
+
+// listGroupChildren paginates through /admin/realms/{realm}/groups/{id}/children
+// and returns all children as raw JSON.
+func (e *Exporter) listGroupChildren(ctx context.Context, groupID string) ([]json.RawMessage, error) {
+	var all []json.RawMessage
+	for offset := 0; ; offset += groupChildrenPageSize {
+		page, err := e.client.GetGroupChildrenRaw(ctx, e.opts.Realm, groupID, map[string]string{
+			"first":               strconv.Itoa(offset),
+			"max":                 strconv.Itoa(groupChildrenPageSize),
+			"briefRepresentation": "false",
+		})
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, page...)
+		if len(page) < groupChildrenPageSize {
+			return all, nil
+		}
+	}
 }
 
 func (e *Exporter) exportUsers(ctx context.Context) ([]ExportedResource, error) {

--- a/internal/export/exporter_test.go
+++ b/internal/export/exporter_test.go
@@ -1,0 +1,390 @@
+package export
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strconv"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+
+	keycloakv1beta1 "github.com/Hostzero-GmbH/keycloak-operator/api/v1beta1"
+	"github.com/Hostzero-GmbH/keycloak-operator/internal/keycloak"
+)
+
+// fakeKeycloak is a minimal Keycloak admin API stand-in used to exercise the
+// exporter against both the legacy (pre-23) inline subGroups response shape
+// and the modern (23+) shape that requires fetching children separately.
+type fakeKeycloak struct {
+	t *testing.T
+
+	// topLevel is the response body for GET /groups for the test realm.
+	topLevel []json.RawMessage
+
+	// children maps a parent group ID to the full children list returned by
+	// GET /groups/{id}/children. The fake paginates the slice using the
+	// `first` and `max` query parameters supplied by the client.
+	children map[string][]json.RawMessage
+
+	// realmRoles maps a group ID to the role mappings returned by
+	// GET /groups/{id}/role-mappings/realm.
+	realmRoles map[string][]json.RawMessage
+
+	// childrenCalls counts requests per group ID for assertions about
+	// pagination and the post-23 fallback.
+	childrenCalls map[string]int
+}
+
+func newFakeKeycloak(t *testing.T) *fakeKeycloak {
+	return &fakeKeycloak{
+		t:             t,
+		children:      map[string][]json.RawMessage{},
+		realmRoles:    map[string][]json.RawMessage{},
+		childrenCalls: map[string]int{},
+	}
+}
+
+func (f *fakeKeycloak) handler() http.Handler {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/realms/master/protocol/openid-connect/token", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"test","expires_in":300,"token_type":"Bearer"}`))
+	})
+
+	mux.HandleFunc("/admin/realms/test/groups", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/admin/realms/test/groups" {
+			http.NotFound(w, r)
+			return
+		}
+		writeJSON(w, f.topLevel)
+	})
+
+	mux.HandleFunc("/admin/realms/test/groups/", func(w http.ResponseWriter, r *http.Request) {
+		// Path forms we care about:
+		//   /admin/realms/test/groups/{id}/children
+		//   /admin/realms/test/groups/{id}/role-mappings/realm
+		rest := r.URL.Path[len("/admin/realms/test/groups/"):]
+		switch {
+		case len(rest) > len("/children") && rest[len(rest)-len("/children"):] == "/children":
+			id := rest[:len(rest)-len("/children")]
+			f.childrenCalls[id]++
+			page := paginate(f.children[id], r.URL.Query())
+			writeJSON(w, page)
+		case len(rest) > len("/role-mappings/realm") && rest[len(rest)-len("/role-mappings/realm"):] == "/role-mappings/realm":
+			id := rest[:len(rest)-len("/role-mappings/realm")]
+			writeJSON(w, f.realmRoles[id])
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	mux.HandleFunc("/admin/realms/test/clients", func(w http.ResponseWriter, _ *http.Request) {
+		// Returning an empty client list is enough: exportGroupRoleMappings
+		// only iterates clients to fetch client-role mappings.
+		writeJSON(w, []json.RawMessage{})
+	})
+
+	return mux
+}
+
+func paginate(items []json.RawMessage, q map[string][]string) []json.RawMessage {
+	first := 0
+	if v := q["first"]; len(v) > 0 {
+		if n, err := strconv.Atoi(v[0]); err == nil {
+			first = n
+		}
+	}
+	max := len(items)
+	if v := q["max"]; len(v) > 0 {
+		if n, err := strconv.Atoi(v[0]); err == nil && n >= 0 {
+			max = n
+		}
+	}
+	if first >= len(items) {
+		return []json.RawMessage{}
+	}
+	end := first + max
+	if end > len(items) {
+		end = len(items)
+	}
+	return items[first:end]
+}
+
+func writeJSON(w http.ResponseWriter, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	body, err := json.Marshal(v)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if body == nil {
+		_, _ = w.Write([]byte("[]"))
+		return
+	}
+	_, _ = w.Write(body)
+}
+
+func newTestExporter(t *testing.T, fake *fakeKeycloak) (*Exporter, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(fake.handler())
+	t.Cleanup(srv.Close)
+
+	client := keycloak.NewClient(keycloak.Config{
+		BaseURL:      srv.URL,
+		Realm:        "master",
+		ClientID:     "admin-cli",
+		ClientSecret: "secret",
+	}, testr.New(t))
+
+	exp := NewExporter(client, testr.New(t), ExporterOptions{
+		Realm:           "test",
+		TargetNamespace: "default",
+	})
+	return exp, srv
+}
+
+func mustJSON(t *testing.T, v interface{}) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}
+
+func collectGroupNames(t *testing.T, resources []ExportedResource) map[string]*keycloakv1beta1.KeycloakGroup {
+	t.Helper()
+	groups := map[string]*keycloakv1beta1.KeycloakGroup{}
+	for _, r := range resources {
+		if r.Kind != "KeycloakGroup" {
+			continue
+		}
+		g, ok := r.Object.(*keycloakv1beta1.KeycloakGroup)
+		if !ok {
+			t.Fatalf("expected *KeycloakGroup, got %T", r.Object)
+		}
+		groups[g.Name] = g
+	}
+	return groups
+}
+
+// TestExportGroups_LegacyInlineSubGroups verifies the pre-23 behavior where
+// the realm-wide /groups response inlines the nested subGroups slice. The
+// exporter must not fetch /children at all in that case.
+func TestExportGroups_LegacyInlineSubGroups(t *testing.T) {
+	fake := newFakeKeycloak(t)
+	fake.topLevel = []json.RawMessage{
+		mustJSON(t, map[string]interface{}{
+			"id":   "parent-id",
+			"name": "parent",
+			"path": "/parent",
+			"subGroups": []map[string]interface{}{{
+				"id":        "child-id",
+				"name":      "child",
+				"path":      "/parent/child",
+				"subGroups": []interface{}{},
+			}},
+		}),
+	}
+
+	exp, _ := newTestExporter(t, fake)
+	resources, err := exp.exportGroups(context.Background())
+	if err != nil {
+		t.Fatalf("exportGroups: %v", err)
+	}
+
+	groups := collectGroupNames(t, resources)
+	if _, ok := groups["parent"]; !ok {
+		t.Fatalf("missing top-level group 'parent', got %v", keys(groups))
+	}
+	if _, ok := groups["parent-child"]; !ok {
+		t.Fatalf("missing child group 'parent-child', got %v", keys(groups))
+	}
+
+	if calls := fake.childrenCalls["parent-id"]; calls != 0 {
+		t.Errorf("did not expect /children calls when subGroups is inline, got %d", calls)
+	}
+}
+
+// TestExportGroups_Keycloak23ChildrenFallback verifies the post-23 behavior:
+// /groups returns subGroupCount > 0 with an empty subGroups array, so the
+// exporter must fall back to /groups/{id}/children to find subgroups, and
+// recurse into them when they themselves have children.
+func TestExportGroups_Keycloak23ChildrenFallback(t *testing.T) {
+	fake := newFakeKeycloak(t)
+	fake.topLevel = []json.RawMessage{
+		mustJSON(t, map[string]interface{}{
+			"id":            "parent-id",
+			"name":          "parent",
+			"path":          "/parent",
+			"subGroupCount": 2,
+			"subGroups":     []interface{}{},
+		}),
+	}
+	fake.children["parent-id"] = []json.RawMessage{
+		mustJSON(t, map[string]interface{}{
+			"id":            "child-a-id",
+			"name":          "child-a",
+			"path":          "/parent/child-a",
+			"subGroupCount": 1,
+			"subGroups":     []interface{}{},
+		}),
+		mustJSON(t, map[string]interface{}{
+			"id":            "child-b-id",
+			"name":          "child-b",
+			"path":          "/parent/child-b",
+			"subGroupCount": 0,
+			"subGroups":     []interface{}{},
+		}),
+	}
+	fake.children["child-a-id"] = []json.RawMessage{
+		mustJSON(t, map[string]interface{}{
+			"id":            "grandchild-id",
+			"name":          "grand",
+			"path":          "/parent/child-a/grand",
+			"subGroupCount": 0,
+			"subGroups":     []interface{}{},
+		}),
+	}
+
+	exp, _ := newTestExporter(t, fake)
+	resources, err := exp.exportGroups(context.Background())
+	if err != nil {
+		t.Fatalf("exportGroups: %v", err)
+	}
+
+	groups := collectGroupNames(t, resources)
+	wantNames := []string{"parent", "parent-child-a", "parent-child-b", "parent-child-a-grand"}
+	for _, name := range wantNames {
+		if _, ok := groups[name]; !ok {
+			t.Fatalf("missing exported group %q, got %v", name, keys(groups))
+		}
+	}
+
+	// Verify parent references on subgroups.
+	if got := groups["parent-child-a"].Spec.ParentGroupRef; got == nil || got.Name != "parent" {
+		t.Errorf("child-a parentGroupRef = %+v, want parent", got)
+	}
+	if got := groups["parent-child-b"].Spec.ParentGroupRef; got == nil || got.Name != "parent" {
+		t.Errorf("child-b parentGroupRef = %+v, want parent", got)
+	}
+	if got := groups["parent-child-a-grand"].Spec.ParentGroupRef; got == nil || got.Name != "parent-child-a" {
+		t.Errorf("grandchild parentGroupRef = %+v, want parent-child-a", got)
+	}
+
+	if calls := fake.childrenCalls["parent-id"]; calls < 1 {
+		t.Errorf("expected at least 1 /children call for parent, got %d", calls)
+	}
+	if calls := fake.childrenCalls["child-a-id"]; calls < 1 {
+		t.Errorf("expected at least 1 /children call for child-a (it has subGroupCount=1), got %d", calls)
+	}
+	if calls := fake.childrenCalls["child-b-id"]; calls != 0 {
+		t.Errorf("did not expect /children call for child-b (subGroupCount=0), got %d", calls)
+	}
+}
+
+// TestExportGroups_ChildrenPagination verifies that the exporter pages through
+// /children when a parent has more children than the page size.
+func TestExportGroups_ChildrenPagination(t *testing.T) {
+	fake := newFakeKeycloak(t)
+	fake.topLevel = []json.RawMessage{
+		mustJSON(t, map[string]interface{}{
+			"id":            "parent-id",
+			"name":          "parent",
+			"path":          "/parent",
+			"subGroupCount": groupChildrenPageSize + 1,
+			"subGroups":     []interface{}{},
+		}),
+	}
+	for i := 0; i < groupChildrenPageSize+1; i++ {
+		fake.children["parent-id"] = append(fake.children["parent-id"], mustJSON(t, map[string]interface{}{
+			"id":            fmt.Sprintf("child-%d-id", i),
+			"name":          fmt.Sprintf("child-%d", i),
+			"path":          fmt.Sprintf("/parent/child-%d", i),
+			"subGroupCount": 0,
+			"subGroups":     []interface{}{},
+		}))
+	}
+
+	exp, _ := newTestExporter(t, fake)
+	resources, err := exp.exportGroups(context.Background())
+	if err != nil {
+		t.Fatalf("exportGroups: %v", err)
+	}
+
+	groups := collectGroupNames(t, resources)
+	if got, want := len(groups), groupChildrenPageSize+2; got != want { // +1 parent
+		t.Fatalf("group count = %d, want %d (parent + %d children)", got, want, groupChildrenPageSize+1)
+	}
+	if calls := fake.childrenCalls["parent-id"]; calls != 2 {
+		t.Errorf("expected 2 paginated /children calls, got %d", calls)
+	}
+}
+
+// TestExportGroups_SubGroupRoleMappings verifies that role mappings are now
+// exported for nested subgroups, not only for top-level groups.
+func TestExportGroups_SubGroupRoleMappings(t *testing.T) {
+	fake := newFakeKeycloak(t)
+	fake.topLevel = []json.RawMessage{
+		mustJSON(t, map[string]interface{}{
+			"id":            "parent-id",
+			"name":          "parent",
+			"path":          "/parent",
+			"subGroupCount": 1,
+			"subGroups":     []interface{}{},
+		}),
+	}
+	fake.children["parent-id"] = []json.RawMessage{
+		mustJSON(t, map[string]interface{}{
+			"id":            "child-id",
+			"name":          "child",
+			"path":          "/parent/child",
+			"subGroupCount": 0,
+			"subGroups":     []interface{}{},
+		}),
+	}
+	fake.realmRoles["child-id"] = []json.RawMessage{
+		mustJSON(t, map[string]interface{}{
+			"id":   "role-id",
+			"name": "viewer",
+		}),
+	}
+
+	exp, _ := newTestExporter(t, fake)
+	resources, err := exp.exportGroups(context.Background())
+	if err != nil {
+		t.Fatalf("exportGroups: %v", err)
+	}
+
+	var foundMapping bool
+	for _, r := range resources {
+		if r.Kind == "KeycloakRoleMapping" {
+			foundMapping = true
+		}
+	}
+	if !foundMapping {
+		t.Fatalf("expected at least one KeycloakRoleMapping for subgroup, got resources: %v", resourceKinds(resources))
+	}
+}
+
+func keys(m map[string]*keycloakv1beta1.KeycloakGroup) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func resourceKinds(rs []ExportedResource) []string {
+	out := make([]string, 0, len(rs))
+	for _, r := range rs {
+		out = append(out, r.Kind+"/"+r.Name)
+	}
+	return out
+}

--- a/internal/keycloak/client.go
+++ b/internal/keycloak/client.go
@@ -558,10 +558,11 @@ func (c *Client) SetPassword(ctx context.Context, realmName, userID, password st
 
 // GroupRepresentation represents a Keycloak group (minimal fields we need)
 type GroupRepresentation struct {
-	ID        *string               `json:"id,omitempty"`
-	Name      *string               `json:"name,omitempty"`
-	Path      *string               `json:"path,omitempty"`
-	SubGroups []GroupRepresentation `json:"subGroups,omitempty"`
+	ID            *string               `json:"id,omitempty"`
+	Name          *string               `json:"name,omitempty"`
+	Path          *string               `json:"path,omitempty"`
+	SubGroupCount *int                  `json:"subGroupCount,omitempty"`
+	SubGroups     []GroupRepresentation `json:"subGroups,omitempty"`
 }
 
 // CreateGroup creates a new group
@@ -587,6 +588,17 @@ func (c *Client) GetGroup(ctx context.Context, realmName, groupID string) (*Grou
 func (c *Client) GetGroups(ctx context.Context, realmName string, params map[string]string) ([]GroupRepresentation, error) {
 	var groups []GroupRepresentation
 	if err := c.List(ctx, "/admin/realms/"+url.PathEscape(realmName)+"/groups", params, &groups); err != nil {
+		return nil, err
+	}
+	return groups, nil
+}
+
+// GetGroupChildren returns direct children of a group.
+// Accepts pagination params (first, max, briefRepresentation, search, exact).
+// Required since Keycloak 23+, where /groups no longer inlines nested subGroups.
+func (c *Client) GetGroupChildren(ctx context.Context, realmName, groupID string, params map[string]string) ([]GroupRepresentation, error) {
+	var groups []GroupRepresentation
+	if err := c.List(ctx, "/admin/realms/"+url.PathEscape(realmName)+"/groups/"+url.PathEscape(groupID)+"/children", params, &groups); err != nil {
 		return nil, err
 	}
 	return groups, nil
@@ -1288,6 +1300,12 @@ func (c *Client) GetGroupsRaw(ctx context.Context, realmName string) ([]json.Raw
 // GetGroupRaw gets a group by ID as raw JSON
 func (c *Client) GetGroupRaw(ctx context.Context, realmName, groupID string) (json.RawMessage, error) {
 	return c.GetRaw(ctx, "/admin/realms/"+url.PathEscape(realmName)+"/groups/"+url.PathEscape(groupID))
+}
+
+// GetGroupChildrenRaw gets direct children of a group as raw JSON.
+// Required since Keycloak 23+, where /groups no longer inlines nested subGroups.
+func (c *Client) GetGroupChildrenRaw(ctx context.Context, realmName, groupID string, params map[string]string) ([]json.RawMessage, error) {
+	return c.ListRaw(ctx, "/admin/realms/"+url.PathEscape(realmName)+"/groups/"+url.PathEscape(groupID)+"/children", params)
 }
 
 // GetClientScopesRaw gets all client scopes in a realm as raw JSON

--- a/test/e2e/group_nested_reconcile_test.go
+++ b/test/e2e/group_nested_reconcile_test.go
@@ -1,0 +1,272 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	keycloakv1beta1 "github.com/Hostzero-GmbH/keycloak-operator/api/v1beta1"
+	"github.com/Hostzero-GmbH/keycloak-operator/internal/keycloak"
+)
+
+// TestKeycloakGroupNestedReconcile exercises the controller code path that
+// looks up nested groups via /groups/{parentID}/children. Since Keycloak 23+
+// the realm-wide /groups response no longer inlines subGroups, so the old
+// recursive findGroupByNameInList walk would return nil for every child
+// lookup and the reconciler would attempt to re-create a duplicate (Keycloak
+// answers with 409) on every reconcile after the initial creation.
+//
+// These tests are integration tests against a real Keycloak (via the operator
+// running in a kind cluster). They require:
+//   - A working in-cluster operator pointed at a Keycloak >= 23
+//   - Direct Keycloak API access from the test environment (port-forward)
+func TestKeycloakGroupNestedReconcile(t *testing.T) {
+	skipIfNoCluster(t)
+	skipIfNoKeycloakAccess(t)
+
+	instanceName, instanceNS := getOrCreateInstance(t)
+	realmName := createTestRealm(t, instanceName, instanceNS, "nested-reconcile")
+	kc := getInternalKeycloakClient(t)
+
+	// ChildSurvivesReReconcile is the most direct regression test for the
+	// controller fix. Before the fix, the second reconcile of a nested child
+	// would hit the buggy lookup, decide the group did not exist, and try to
+	// create a duplicate — Keycloak returns 409 and the CR ends up in
+	// CreateFailed.
+	t.Run("ChildSurvivesReReconcile", func(t *testing.T) {
+		suffix := time.Now().UnixNano()
+		parentKCName := fmt.Sprintf("nrc-parent-%d", suffix)
+		childKCName := fmt.Sprintf("nrc-child-%d", suffix)
+
+		parent := newGroupCR(t, fmt.Sprintf("p-%d", suffix), realmName, "", parentKCName, nil)
+		require.NoError(t, k8sClient.Create(ctx, parent))
+		t.Cleanup(func() { _ = k8sClient.Delete(ctx, parent) })
+		parentID := waitGroupReadyAndGetID(t, parent)
+
+		child := newGroupCR(t, fmt.Sprintf("c-%d", suffix), realmName, parent.Name, childKCName, nil)
+		require.NoError(t, k8sClient.Create(ctx, child))
+		t.Cleanup(func() { _ = k8sClient.Delete(ctx, child) })
+		childID := waitGroupReadyAndGetID(t, child)
+
+		assertParentHasChildIDs(t, kc, realmName, parentID, []string{childID})
+
+		// Force a re-reconcile by adding an attribute. Without the controller
+		// fix the second reconcile would call CreateChildGroup again and
+		// Keycloak would reject it with 409, dropping the CR into
+		// CreateFailed. With the fix, the lookup finds the existing child
+		// and the operator calls UpdateGroup instead.
+		updateGroupDefinition(t, child, childKCName, map[string][]string{
+			"reconciled": {"true"},
+		})
+
+		waitGroupAttributeApplied(t, kc, realmName, childID, "reconciled", "true")
+		requireGroupStillReady(t, child, childID)
+		assertParentHasChildIDs(t, kc, realmName, parentID, []string{childID})
+	})
+
+	// SameNameChildrenUnderDifferentParents proves that the new lookup is
+	// correctly scoped to the parent's /children endpoint. The pre-fix
+	// recursive findGroupByNameInList walked the realm-wide response and
+	// could return any group with a matching name, regardless of parent.
+	t.Run("SameNameChildrenUnderDifferentParents", func(t *testing.T) {
+		suffix := time.Now().UnixNano()
+		sharedKCName := fmt.Sprintf("nrc-shared-%d", suffix)
+
+		parentA := newGroupCR(t, fmt.Sprintf("pa-%d", suffix), realmName, "", fmt.Sprintf("nrc-pa-%d", suffix), nil)
+		require.NoError(t, k8sClient.Create(ctx, parentA))
+		t.Cleanup(func() { _ = k8sClient.Delete(ctx, parentA) })
+		parentAID := waitGroupReadyAndGetID(t, parentA)
+
+		parentB := newGroupCR(t, fmt.Sprintf("pb-%d", suffix), realmName, "", fmt.Sprintf("nrc-pb-%d", suffix), nil)
+		require.NoError(t, k8sClient.Create(ctx, parentB))
+		t.Cleanup(func() { _ = k8sClient.Delete(ctx, parentB) })
+		parentBID := waitGroupReadyAndGetID(t, parentB)
+
+		childA := newGroupCR(t, fmt.Sprintf("ca-%d", suffix), realmName, parentA.Name, sharedKCName, nil)
+		require.NoError(t, k8sClient.Create(ctx, childA))
+		t.Cleanup(func() { _ = k8sClient.Delete(ctx, childA) })
+		childAID := waitGroupReadyAndGetID(t, childA)
+
+		childB := newGroupCR(t, fmt.Sprintf("cb-%d", suffix), realmName, parentB.Name, sharedKCName, nil)
+		require.NoError(t, k8sClient.Create(ctx, childB))
+		t.Cleanup(func() { _ = k8sClient.Delete(ctx, childB) })
+		childBID := waitGroupReadyAndGetID(t, childB)
+
+		require.NotEqual(t, childAID, childBID, "same-name children under different parents must be distinct Keycloak groups")
+		assertParentHasChildIDs(t, kc, realmName, parentAID, []string{childAID})
+		assertParentHasChildIDs(t, kc, realmName, parentBID, []string{childBID})
+
+		// Re-reconcile childA. The controller must scope the lookup to
+		// parentA's children and update childA — not childB, which has the
+		// same Keycloak group name but lives under parentB.
+		updateGroupDefinition(t, childA, sharedKCName, map[string][]string{
+			"side": {"a"},
+		})
+
+		waitGroupAttributeApplied(t, kc, realmName, childAID, "side", "a")
+		requireGroupStillReady(t, childA, childAID)
+
+		// childB must still exist, must not have been touched, and must
+		// remain under parentB.
+		rawB, err := kc.GetGroupRaw(ctx, realmName, childBID)
+		require.NoError(t, err)
+		var parsedB struct {
+			Attributes map[string][]string `json:"attributes"`
+		}
+		require.NoError(t, json.Unmarshal(rawB, &parsedB))
+		require.Empty(t, parsedB.Attributes["side"], "childB must not have been updated when reconciling childA")
+
+		assertParentHasChildIDs(t, kc, realmName, parentAID, []string{childAID})
+		assertParentHasChildIDs(t, kc, realmName, parentBID, []string{childBID})
+	})
+}
+
+// newGroupCR builds a KeycloakGroup CR with the given Keycloak group name
+// (set inside the definition) and an optional parent K8s CR name.
+func newGroupCR(t *testing.T, k8sName, realmName, parentK8sName, kcGroupName string, attrs map[string][]string) *keycloakv1beta1.KeycloakGroup {
+	t.Helper()
+
+	body := map[string]interface{}{"name": kcGroupName}
+	if len(attrs) > 0 {
+		body["attributes"] = attrs
+	}
+	def, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	g := &keycloakv1beta1.KeycloakGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      k8sName,
+			Namespace: testNamespace,
+		},
+		Spec: keycloakv1beta1.KeycloakGroupSpec{
+			RealmRef:   &keycloakv1beta1.ResourceRef{Name: realmName},
+			Definition: rawJSON(string(def)),
+		},
+	}
+	if parentK8sName != "" {
+		g.Spec.ParentGroupRef = &keycloakv1beta1.ResourceRef{Name: parentK8sName}
+	}
+	return g
+}
+
+func waitGroupReadyAndGetID(t *testing.T, group *keycloakv1beta1.KeycloakGroup) string {
+	t.Helper()
+	var groupID string
+	err := wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+		updated := &keycloakv1beta1.KeycloakGroup{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{
+			Name:      group.Name,
+			Namespace: group.Namespace,
+		}, updated); err != nil {
+			return false, nil
+		}
+		if !updated.Status.Ready || updated.Status.GroupID == "" {
+			return false, nil
+		}
+		groupID = updated.Status.GroupID
+		return true, nil
+	})
+	require.NoErrorf(t, err, "KeycloakGroup %s did not become ready (status=%s)", group.Name, currentGroupStatus(group))
+	return groupID
+}
+
+// updateGroupDefinition fetches the latest copy of the CR, replaces its
+// Definition, and pushes the update — which triggers a re-reconcile.
+func updateGroupDefinition(t *testing.T, group *keycloakv1beta1.KeycloakGroup, kcName string, attrs map[string][]string) {
+	t.Helper()
+
+	body := map[string]interface{}{
+		"name":       kcName,
+		"attributes": attrs,
+	}
+	def, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		current := &keycloakv1beta1.KeycloakGroup{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{
+			Name:      group.Name,
+			Namespace: group.Namespace,
+		}, current); err != nil {
+			return false
+		}
+		current.Spec.Definition = rawJSON(string(def))
+		return k8sClient.Update(ctx, current) == nil
+	}, timeout, interval, "failed to update KeycloakGroup %s", group.Name)
+}
+
+// waitGroupAttributeApplied polls Keycloak until the group has the given
+// attribute value applied, proving that the operator successfully called
+// UpdateGroup on the existing nested child.
+func waitGroupAttributeApplied(t *testing.T, kc *keycloak.Client, realmName, groupID, attrKey, want string) {
+	t.Helper()
+	require.Eventuallyf(t, func() bool {
+		raw, err := kc.GetGroupRaw(ctx, realmName, groupID)
+		if err != nil {
+			return false
+		}
+		var parsed struct {
+			Attributes map[string][]string `json:"attributes"`
+		}
+		if err := json.Unmarshal(raw, &parsed); err != nil {
+			return false
+		}
+		vs := parsed.Attributes[attrKey]
+		return len(vs) == 1 && vs[0] == want
+	}, timeout, interval, "group %s never received attribute %s=%s in Keycloak", groupID, attrKey, want)
+}
+
+// requireGroupStillReady asserts the CR remained Ready (i.e. the re-reconcile
+// did not drop into CreateFailed) and the GroupID was not changed.
+func requireGroupStillReady(t *testing.T, group *keycloakv1beta1.KeycloakGroup, expectedID string) {
+	t.Helper()
+	final := &keycloakv1beta1.KeycloakGroup{}
+	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{
+		Name:      group.Name,
+		Namespace: group.Namespace,
+	}, final))
+	require.Truef(t, final.Status.Ready,
+		"KeycloakGroup %s should remain Ready after re-reconcile, got status=%q message=%q",
+		group.Name, final.Status.Status, final.Status.Message)
+	require.Equal(t, expectedID, final.Status.GroupID, "GroupID must remain stable across re-reconcile")
+}
+
+// assertParentHasChildIDs verifies that the given parent's children in
+// Keycloak are exactly the expected set of group IDs (no missing, no
+// duplicates).
+func assertParentHasChildIDs(t *testing.T, kc *keycloak.Client, realmName, parentID string, wantIDs []string) {
+	t.Helper()
+	got, err := kc.GetGroupChildren(ctx, realmName, parentID, nil)
+	require.NoError(t, err)
+
+	gotIDs := make([]string, 0, len(got))
+	for i := range got {
+		if got[i].ID == nil {
+			continue
+		}
+		gotIDs = append(gotIDs, *got[i].ID)
+	}
+	require.ElementsMatchf(t, wantIDs, gotIDs,
+		"parent %s children mismatch (expected %v, got %v)", parentID, wantIDs, gotIDs)
+}
+
+// currentGroupStatus returns a small string describing the latest observed
+// status of the CR — only used for failure messages.
+func currentGroupStatus(group *keycloakv1beta1.KeycloakGroup) string {
+	got := &keycloakv1beta1.KeycloakGroup{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{
+		Name:      group.Name,
+		Namespace: group.Namespace,
+	}, got); err != nil {
+		return fmt.Sprintf("get failed: %v", err)
+	}
+	return fmt.Sprintf("ready=%t status=%q message=%q groupID=%s",
+		got.Status.Ready, got.Status.Status, got.Status.Message, got.Status.GroupID)
+}


### PR DESCRIPTION
Since Keycloak 23, GET /admin/realms/{realm}/groups returns groups with subGroupCount but an empty subGroups array; nested groups must be fetched via /groups/{id}/children. Two code paths still assumed the legacy inline shape and silently dropped every nested group.

Exporter (internal/export/exporter.go):
  When a group reports subGroupCount > 0 but no inline subGroups, page
  through /groups/{id}/children to discover and recursively export the
  nested hierarchy. Also export role mappings for subgroups, which were
  previously only exported for top-level groups.

Group controller (internal/controller/keycloakgroup_controller.go):
  When ParentGroupRef is set, scope the existence check to the parent's
  /children endpoint instead of a realm-wide search + recursive walk over
  an empty SubGroups slice. Without this, every reconcile after the
  initial create attempted CreateChildGroup again and Keycloak returned
  409, dropping the CR into CreateFailed. Replaces findGroupByNameInList
  (which also returned cross-parent matches by name) with a strict
  top-level helper.

Keycloak client (internal/keycloak/client.go):
  Add GetGroupChildren / GetGroupChildrenRaw and SubGroupCount on
  GroupRepresentation.

Tests:
  - internal/export/exporter_test.go: httptest-backed exporter tests covering the legacy inline shape, the 23+ children fallback, /children pagination, and role-mapping export for subgroups.
  - internal/controller/keycloakgroup_controller_test.go: unit test pinning the new top-level lookup helper contract.
  - test/e2e/group_nested_reconcile_test.go: integration tests against a real Keycloak that re-reconcile a nested child (proves no duplicate is created on the second reconcile) and create same-named children under different parents (proves the lookup is parent-scoped).

Fixed #53 