### PR TITLE
Add drift-detection across all controllers to skip redundant updates

### DIFF
--- a/internal/controller/clusterkeycloakrealm_controller.go
+++ b/internal/controller/clusterkeycloakrealm_controller.go
@@ -131,14 +131,29 @@ func (r *ClusterKeycloakRealmReconciler) Reconcile(ctx context.Context, req ctrl
 		}
 		log.Info("realm created successfully", "realm", realmDef.Realm)
 	} else {
-		// Realm exists, update it - merge ID into definition
-		log.Info("updating realm", "realm", realmDef.Realm)
+		// Realm exists — check if update is needed
 		definition = mergeIDIntoDefinition(definition, existingRealm.ID)
-		if err := kc.UpdateRealm(ctx, realmDef.Realm, definition); err != nil {
-			RecordError(controllerName, "keycloak_api_error")
-			return r.updateStatus(ctx, realm, false, "UpdateFailed", fmt.Sprintf("Failed to update realm: %v", err), instanceRef)
+
+		// Fetch current state from Keycloak for drift detection
+		currentRaw, fetchErr := kc.GetRealmRaw(ctx, realmDef.Realm)
+
+		needsUpdate := true
+		if fetchErr != nil {
+			log.Error(fetchErr, "failed to fetch current realm state, falling through to update")
+		} else if currentRaw != nil {
+			needsUpdate = !definitionsMatch(definition, currentRaw)
 		}
-		log.Info("realm updated successfully", "realm", realmDef.Realm)
+
+		if needsUpdate {
+			log.Info("updating realm", "realm", realmDef.Realm)
+			if err := kc.UpdateRealm(ctx, realmDef.Realm, definition); err != nil {
+				RecordError(controllerName, "keycloak_api_error")
+				return r.updateStatus(ctx, realm, false, "UpdateFailed", fmt.Sprintf("Failed to update realm: %v", err), instanceRef)
+			}
+			log.Info("realm updated successfully", "realm", realmDef.Realm)
+		} else {
+			log.V(1).Info("realm already in sync, skipping update", "realm", realmDef.Realm)
+		}
 	}
 
 	// Update status
@@ -235,27 +250,52 @@ func (r *ClusterKeycloakRealmReconciler) deleteRealm(ctx context.Context, realm 
 }
 
 func (r *ClusterKeycloakRealmReconciler) updateStatus(ctx context.Context, realm *keycloakv1beta1.ClusterKeycloakRealm, ready bool, status, message string, instanceRef *keycloakv1beta1.InstanceRef) (ctrl.Result, error) {
+	desiredConditionStatus := metav1.ConditionFalse
+	if ready {
+		desiredConditionStatus = metav1.ConditionTrue
+	}
+
+	// Detect whether any user-visible status field actually changed
+	statusChanged := realm.Status.Ready != ready ||
+		realm.Status.Status != status ||
+		realm.Status.Message != message
+
+	conditionChanged := true
+	for _, c := range realm.Status.Conditions {
+		if c.Type == "Ready" && c.Status == desiredConditionStatus && c.Reason == status && c.Message == message {
+			conditionChanged = false
+			break
+		}
+	}
+
+	if !statusChanged && !conditionChanged {
+		// Nothing changed — skip the API write to avoid triggering a watch-event reconcile loop
+		if ready {
+			return ctrl.Result{RequeueAfter: GetSyncPeriod()}, nil
+		}
+		return ctrl.Result{RequeueAfter: ErrorRequeueDelay}, nil
+	}
+
 	realm.Status.Ready = ready
 	realm.Status.Status = status
 	realm.Status.Message = message
 	realm.Status.Instance = instanceRef
 
-	// Update conditions
 	condition := metav1.Condition{
 		Type:               "Ready",
-		Status:             metav1.ConditionFalse,
+		Status:             desiredConditionStatus,
 		Reason:             status,
 		Message:            message,
 		LastTransitionTime: metav1.Now(),
 	}
-	if ready {
-		condition.Status = metav1.ConditionTrue
-	}
 
-	// Update or add condition
 	found := false
 	for i, c := range realm.Status.Conditions {
 		if c.Type == "Ready" {
+			// Preserve LastTransitionTime if status did not flip
+			if c.Status == desiredConditionStatus {
+				condition.LastTransitionTime = c.LastTransitionTime
+			}
 			realm.Status.Conditions[i] = condition
 			found = true
 			break

--- a/internal/controller/clusterkeycloakrealm_controller.go
+++ b/internal/controller/clusterkeycloakrealm_controller.go
@@ -141,7 +141,7 @@ func (r *ClusterKeycloakRealmReconciler) Reconcile(ctx context.Context, req ctrl
 		if fetchErr != nil {
 			log.Error(fetchErr, "failed to fetch current realm state, falling through to update")
 		} else if currentRaw != nil {
-			needsUpdate = !definitionsMatch(definition, currentRaw)
+			needsUpdate = !realmDefinitionsMatch(definition, currentRaw)
 		}
 
 		if needsUpdate {

--- a/internal/controller/keycloak_config.go
+++ b/internal/controller/keycloak_config.go
@@ -441,6 +441,52 @@ func mergeIDPConfig(definition json.RawMessage, secretData map[string]string) js
 	return result
 }
 
+// idpDefinitionsMatch compares two IdentityProviderRepresentations for drift-detection,
+// stripping fields that Keycloak masks on GET so they don't cause false-positive drift
+// (which would otherwise produce an endless update-loop with each reconcile).
+//
+// Keycloak's `GET /admin/realms/.../identity-provider/instances/{alias}` returns
+// `config.clientSecret` as the literal string "**********" instead of the stored value
+// — but ONLY when a secret is set. If the IdP has no secret, the field is null/absent.
+//
+// We strip clientSecret from BOTH sides ONLY when current shows the mask: that means
+// Keycloak has *some* secret stored, we can't compare it against our desired value
+// anyway, so treat them as equal on that field. If current is null/missing, the IdP
+// genuinely has no secret yet and our PUT must push it — leave the field intact so
+// the diff fires.
+//
+// Pace patch: paired with the new drift-detection in keycloakidentityprovider_controller.go.
+func idpDefinitionsMatch(desired, current json.RawMessage) bool {
+	var desiredMap, currentMap map[string]interface{}
+	if err := json.Unmarshal(desired, &desiredMap); err != nil {
+		return false
+	}
+	if err := json.Unmarshal(current, &currentMap); err != nil {
+		return false
+	}
+
+	// If Keycloak masked clientSecret in the current state, drop it from both
+	// sides so the unobservable value doesn't cause false drift.
+	if cCfg, ok := currentMap["config"].(map[string]interface{}); ok {
+		if cs, ok := cCfg["clientSecret"].(string); ok && cs == "**********" {
+			delete(cCfg, "clientSecret")
+			if dCfg, ok := desiredMap["config"].(map[string]interface{}); ok {
+				delete(dCfg, "clientSecret")
+			}
+		}
+	}
+
+	desiredJSON, err := json.Marshal(desiredMap)
+	if err != nil {
+		return false
+	}
+	currentJSON, err := json.Marshal(currentMap)
+	if err != nil {
+		return false
+	}
+	return definitionsMatch(desiredJSON, currentJSON)
+}
+
 // removeFieldFromDefinition removes a field from a JSON definition.
 // If the field doesn't exist or the JSON is invalid, the original is returned unchanged.
 func removeFieldFromDefinition(definition json.RawMessage, field string) json.RawMessage {

--- a/internal/controller/keycloak_config.go
+++ b/internal/controller/keycloak_config.go
@@ -487,6 +487,47 @@ func idpDefinitionsMatch(desired, current json.RawMessage) bool {
 	return definitionsMatch(desiredJSON, currentJSON)
 }
 
+// realmDefinitionsMatch compares two RealmRepresentations for drift-detection,
+// stripping fields that Keycloak masks on GET so they don't cause false-positive drift.
+//
+// Keycloak masks `smtpServer.password` as "**********" on GET when an SMTP password
+// is configured. If the operator merges a real password from smtpSecretRef into the
+// desired definition, a naive comparison would always report drift and force an
+// UpdateRealm every reconcile.
+//
+// We strip smtpServer.password from BOTH sides ONLY when current shows the mask:
+// Keycloak has *some* password stored, we can't observe its value, so treat as equal
+// on that field. If current is null/missing, the realm genuinely has no password
+// stored and the PUT must push it — leave the field intact so the diff fires.
+func realmDefinitionsMatch(desired, current json.RawMessage) bool {
+	var desiredMap, currentMap map[string]interface{}
+	if err := json.Unmarshal(desired, &desiredMap); err != nil {
+		return false
+	}
+	if err := json.Unmarshal(current, &currentMap); err != nil {
+		return false
+	}
+
+	if cSmtp, ok := currentMap["smtpServer"].(map[string]interface{}); ok {
+		if pw, ok := cSmtp["password"].(string); ok && pw == "**********" {
+			delete(cSmtp, "password")
+			if dSmtp, ok := desiredMap["smtpServer"].(map[string]interface{}); ok {
+				delete(dSmtp, "password")
+			}
+		}
+	}
+
+	desiredJSON, err := json.Marshal(desiredMap)
+	if err != nil {
+		return false
+	}
+	currentJSON, err := json.Marshal(currentMap)
+	if err != nil {
+		return false
+	}
+	return definitionsMatch(desiredJSON, currentJSON)
+}
+
 // removeFieldFromDefinition removes a field from a JSON definition.
 // If the field doesn't exist or the JSON is invalid, the original is returned unchanged.
 func removeFieldFromDefinition(definition json.RawMessage, field string) json.RawMessage {

--- a/internal/controller/keycloak_config_test.go
+++ b/internal/controller/keycloak_config_test.go
@@ -756,3 +756,35 @@ func TestSetReadyCondition(t *testing.T) {
 		}
 	})
 }
+
+func TestRealmDefinitionsMatch_SmtpPasswordMasked(t *testing.T) {
+	// Desired carries the real password (just merged from smtpSecretRef);
+	// current is masked. realmDefinitionsMatch must treat them as equal.
+	desired := json.RawMessage(`{"realm":"r","smtpServer":{"host":"smtp.example.com","user":"u","password":"plaintext"}}`)
+	current := json.RawMessage(`{"realm":"r","smtpServer":{"host":"smtp.example.com","user":"u","password":"**********"}}`)
+
+	if !realmDefinitionsMatch(desired, current) {
+		t.Error("expected match: smtpServer.password mask should be ignored on the current side")
+	}
+}
+
+func TestRealmDefinitionsMatch_SmtpPasswordUnmasked(t *testing.T) {
+	// If current is not masked (e.g. realm freshly created, no password yet),
+	// the diff must fire so the PUT pushes the password.
+	desired := json.RawMessage(`{"realm":"r","smtpServer":{"host":"smtp.example.com","user":"u","password":"plaintext"}}`)
+	current := json.RawMessage(`{"realm":"r","smtpServer":{"host":"smtp.example.com","user":"u"}}`)
+
+	if realmDefinitionsMatch(desired, current) {
+		t.Error("expected no match: current has no password, desired must push it")
+	}
+}
+
+func TestRealmDefinitionsMatch_NonSmtpFieldDiff(t *testing.T) {
+	// Non-smtp field drift must still be detected even when smtp is masked.
+	desired := json.RawMessage(`{"realm":"r","displayName":"new","smtpServer":{"password":"plaintext"}}`)
+	current := json.RawMessage(`{"realm":"r","displayName":"old","smtpServer":{"password":"**********"}}`)
+
+	if realmDefinitionsMatch(desired, current) {
+		t.Error("expected no match: displayName differs")
+	}
+}

--- a/internal/controller/keycloakclient_controller.go
+++ b/internal/controller/keycloakclient_controller.go
@@ -855,7 +855,6 @@ func toObjectSlice(v interface{}) ([]map[string]interface{}, bool) {
 	return result, true
 }
 
-
 // SetupWithManager sets up the controller with the Manager
 func (r *KeycloakClientReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/keycloakclient_controller.go
+++ b/internal/controller/keycloakclient_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -173,16 +174,30 @@ func (r *KeycloakClientReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 		log.Info("client created successfully", "clientId", clientDef.ClientID, "uuid", clientUUID)
 	} else {
-		// Client exists, update it
+		// Client exists — check if update is needed
 		clientUUID = *existingClient.ID
 		definition = mergeIDIntoDefinition(definition, existingClient.ID)
 
-		log.Info("updating client", "clientId", clientDef.ClientID, "realm", realmName)
-		if err := kc.UpdateClient(ctx, realmName, clientUUID, definition); err != nil {
-			RecordError(controllerName, "keycloak_api_error")
-			return r.updateStatus(ctx, kcClient, false, "UpdateFailed", fmt.Sprintf("Failed to update client: %v", err), clientUUID, instanceRef, realmRef)
+		// Fetch current state from Keycloak for drift detection
+		currentRaw, fetchErr := kc.GetClientRaw(ctx, realmName, clientUUID)
+
+		needsUpdate := true
+		if fetchErr != nil {
+			log.Error(fetchErr, "failed to fetch current client state, falling through to update")
+		} else if currentRaw != nil {
+			needsUpdate = !definitionsMatch(definition, currentRaw)
 		}
-		log.Info("client updated successfully", "clientId", clientDef.ClientID)
+
+		if needsUpdate {
+			log.Info("updating client", "clientId", clientDef.ClientID, "realm", realmName)
+			if err := kc.UpdateClient(ctx, realmName, clientUUID, definition); err != nil {
+				RecordError(controllerName, "keycloak_api_error")
+				return r.updateStatus(ctx, kcClient, false, "UpdateFailed", fmt.Sprintf("Failed to update client: %v", err), clientUUID, instanceRef, realmRef)
+			}
+			log.Info("client updated successfully", "clientId", clientDef.ClientID)
+		} else {
+			log.V(1).Info("client already in sync, skipping update", "clientId", clientDef.ClientID)
+		}
 	}
 
 	// Sync default/optional client scope assignments
@@ -608,6 +623,37 @@ func (r *KeycloakClientReconciler) deleteClient(ctx context.Context, kcClient *k
 }
 
 func (r *KeycloakClientReconciler) updateStatus(ctx context.Context, kcClient *keycloakv1beta1.KeycloakClient, ready bool, status, message, clientUUID string, instanceRef *keycloakv1beta1.InstanceRef, realmRef *keycloakv1beta1.RealmRef) (ctrl.Result, error) {
+	// Determine desired condition status
+	desiredConditionStatus := metav1.ConditionFalse
+	if ready {
+		desiredConditionStatus = metav1.ConditionTrue
+	}
+
+	// Check if status actually changed
+	statusChanged := kcClient.Status.Ready != ready ||
+		kcClient.Status.Status != status ||
+		kcClient.Status.Message != message ||
+		kcClient.Status.ClientUUID != clientUUID
+
+	conditionChanged := true
+	for _, c := range kcClient.Status.Conditions {
+		if c.Type == "Ready" && c.Status == desiredConditionStatus && c.Reason == status && c.Message == message {
+			conditionChanged = false
+			break
+		}
+	}
+
+	// Check if observed generation changed
+	generationChanged := ready && kcClient.Status.ObservedGeneration != kcClient.Generation
+
+	if !statusChanged && !conditionChanged && !generationChanged {
+		// Nothing changed, just requeue without writing to API
+		if ready {
+			return ctrl.Result{RequeueAfter: GetSyncPeriod()}, nil
+		}
+		return ctrl.Result{RequeueAfter: ErrorRequeueDelay}, nil
+	}
+
 	kcClient.Status.Ready = ready
 	kcClient.Status.Status = status
 	kcClient.Status.Message = message
@@ -623,19 +669,20 @@ func (r *KeycloakClientReconciler) updateStatus(ctx context.Context, kcClient *k
 	// Update conditions
 	condition := metav1.Condition{
 		Type:               "Ready",
-		Status:             metav1.ConditionFalse,
+		Status:             desiredConditionStatus,
 		Reason:             status,
 		Message:            message,
 		LastTransitionTime: metav1.Now(),
-	}
-	if ready {
-		condition.Status = metav1.ConditionTrue
 	}
 
 	// Update or add condition
 	found := false
 	for i, c := range kcClient.Status.Conditions {
 		if c.Type == "Ready" {
+			// Preserve LastTransitionTime if status didn't change
+			if c.Status == desiredConditionStatus {
+				condition.LastTransitionTime = c.LastTransitionTime
+			}
 			kcClient.Status.Conditions[i] = condition
 			found = true
 			break
@@ -654,6 +701,153 @@ func (r *KeycloakClientReconciler) updateStatus(ctx context.Context, kcClient *k
 	}
 	return ctrl.Result{RequeueAfter: ErrorRequeueDelay}, nil
 }
+
+// definitionsMatch compares desired definition against the current state in Keycloak.
+// Only fields present in the desired definition are compared — extra fields returned
+// by Keycloak (like access, authenticationFlowBindingOverrides, etc.) are ignored.
+// Array fields (e.g. defaultClientScopes, redirectUris) are compared as unordered sets
+// because Keycloak may return them in arbitrary order.
+func definitionsMatch(desired, current json.RawMessage) bool {
+	var desiredMap, currentMap map[string]interface{}
+	if err := json.Unmarshal(desired, &desiredMap); err != nil {
+		return false
+	}
+	if err := json.Unmarshal(current, &currentMap); err != nil {
+		return false
+	}
+
+	for key, desiredVal := range desiredMap {
+		// defaultClientScopes and optionalClientScopes are reconciled via dedicated
+		// scope-assignment endpoints (see syncClientScopes); the client representation
+		// PUT/GET round-trip doesn't faithfully preserve them, so skip in the diff.
+		if key == "defaultClientScopes" || key == "optionalClientScopes" {
+			continue
+		}
+		currentVal, exists := currentMap[key]
+		if !exists {
+			return false
+		}
+		if !valuesMatch(desiredVal, currentVal) {
+			return false
+		}
+	}
+	return true
+}
+
+// valuesMatch compares two values, treating JSON arrays as unordered sets of strings
+// when all elements are strings. This prevents false diffs caused by Keycloak returning
+// array fields like defaultClientScopes in non-deterministic order.
+func valuesMatch(desired, current interface{}) bool {
+	desiredArr, dIsArr := toStringSlice(desired)
+	currentArr, cIsArr := toStringSlice(current)
+	if dIsArr && cIsArr {
+		if len(desiredArr) != len(currentArr) {
+			return false
+		}
+		sort.Strings(desiredArr)
+		sort.Strings(currentArr)
+		for i := range desiredArr {
+			if desiredArr[i] != currentArr[i] {
+				return false
+			}
+		}
+		return true
+	}
+
+	// Maps: subset comparison (e.g. attributes — CR defines a subset, KC adds defaults)
+	desiredMap, dIsMap := desired.(map[string]interface{})
+	currentMap, cIsMap := current.(map[string]interface{})
+	if dIsMap && cIsMap {
+		for k, dv := range desiredMap {
+			cv, exists := currentMap[k]
+			if !exists {
+				return false
+			}
+			if !valuesMatch(dv, cv) {
+				return false
+			}
+		}
+		return true
+	}
+
+	// Arrays of objects (e.g. protocolMappers): match by "name" field, then subset-compare
+	desiredObjArr, dIsObjArr := toObjectSlice(desired)
+	currentObjArr, cIsObjArr := toObjectSlice(current)
+	if dIsObjArr && cIsObjArr {
+		for _, dObj := range desiredObjArr {
+			dName, _ := dObj["name"].(string)
+			found := false
+			for _, cObj := range currentObjArr {
+				cName, _ := cObj["name"].(string)
+				if dName != "" && dName == cName {
+					// Subset compare: all desired fields must match
+					match := true
+					for k, dv := range dObj {
+						cv, exists := cObj[k]
+						if !exists {
+							match = false
+							break
+						}
+						if !valuesMatch(dv, cv) {
+							match = false
+							break
+						}
+					}
+					if match {
+						found = true
+					}
+					break
+				}
+			}
+			if !found {
+				return false
+			}
+		}
+		return true
+	}
+
+	dj, err1 := json.Marshal(desired)
+	cj, err2 := json.Marshal(current)
+	if err1 != nil || err2 != nil {
+		return false
+	}
+	return string(dj) == string(cj)
+}
+
+// toStringSlice checks if a value is a JSON array of strings and returns it as []string.
+func toStringSlice(v interface{}) ([]string, bool) {
+	arr, ok := v.([]interface{})
+	if !ok {
+		return nil, false
+	}
+	result := make([]string, 0, len(arr))
+	for _, item := range arr {
+		s, ok := item.(string)
+		if !ok {
+			return nil, false
+		}
+		result = append(result, s)
+	}
+	return result, true
+}
+
+// toObjectSlice checks if a value is a JSON array of objects and returns it as []map[string]interface{}.
+func toObjectSlice(v interface{}) ([]map[string]interface{}, bool) {
+	arr, ok := v.([]interface{})
+	if !ok || len(arr) == 0 {
+		return nil, false
+	}
+	result := make([]map[string]interface{}, 0, len(arr))
+	for _, item := range arr {
+		obj, ok := item.(map[string]interface{})
+		if !ok {
+			return nil, false
+		}
+		result = append(result, obj)
+	}
+	return result, true
+}
+
 
 // SetupWithManager sets up the controller with the Manager
 func (r *KeycloakClientReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/internal/controller/keycloakclient_controller.go
+++ b/internal/controller/keycloakclient_controller.go
@@ -770,10 +770,17 @@ func valuesMatch(desired, current interface{}) bool {
 		return true
 	}
 
-	// Arrays of objects (e.g. protocolMappers): match by "name" field, then subset-compare
+	// Arrays of objects (e.g. protocolMappers): match by "name" field, require same
+	// length so that extra objects in Keycloak (e.g. an orphaned protocolMapper that
+	// the CR no longer declares) are detected as drift and removed by the PUT.
+	// Within each matched object, fields are still subset-compared because Keycloak
+	// adds fields the CR omits (id, consentRequired, ...).
 	desiredObjArr, dIsObjArr := toObjectSlice(desired)
 	currentObjArr, cIsObjArr := toObjectSlice(current)
 	if dIsObjArr && cIsObjArr {
+		if len(desiredObjArr) != len(currentObjArr) {
+			return false
+		}
 		for _, dObj := range desiredObjArr {
 			dName, _ := dObj["name"].(string)
 			found := false

--- a/internal/controller/keycloakclient_controller_test.go
+++ b/internal/controller/keycloakclient_controller_test.go
@@ -1,0 +1,164 @@
+package controller
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestDefinitionsMatch_ScopesUnordered(t *testing.T) {
+	desired := json.RawMessage(`{
+		"clientId": "user",
+		"defaultClientScopes": ["basic", "scope-a", "scope-b", "scope-c"]
+	}`)
+	current := json.RawMessage(`{
+		"clientId": "user",
+		"defaultClientScopes": ["scope-c", "scope-a", "basic", "scope-b"],
+		"access": {"configure": true}
+	}`)
+
+	if !definitionsMatch(desired, current) {
+		t.Error("expected match: same scopes in different order should be equal")
+	}
+}
+
+func TestDefinitionsMatch_ScalarFieldDiff(t *testing.T) {
+	desired := json.RawMessage(`{
+		"clientId": "user",
+		"publicClient": true
+	}`)
+	current := json.RawMessage(`{
+		"clientId": "user",
+		"publicClient": false
+	}`)
+
+	if definitionsMatch(desired, current) {
+		t.Error("expected no match: publicClient differs")
+	}
+}
+
+func TestDefinitionsMatch_ExtraFieldsIgnored(t *testing.T) {
+	desired := json.RawMessage(`{
+		"clientId": "user"
+	}`)
+	current := json.RawMessage(`{
+		"clientId": "user",
+		"access": {"configure": true},
+		"attributes": {"realm_client": "false"}
+	}`)
+
+	if !definitionsMatch(desired, current) {
+		t.Error("expected match: extra fields in Keycloak should be ignored")
+	}
+}
+
+func TestDefinitionsMatch_RedirectUrisUnordered(t *testing.T) {
+	desired := json.RawMessage(`{
+		"clientId": "app",
+		"redirectUris": ["https://a.com/*", "https://b.com/*"]
+	}`)
+	current := json.RawMessage(`{
+		"clientId": "app",
+		"redirectUris": ["https://b.com/*", "https://a.com/*"]
+	}`)
+
+	if !definitionsMatch(desired, current) {
+		t.Error("expected match: same redirectUris in different order should be equal")
+	}
+}
+
+func TestDefinitionsMatch_EmptyScopes(t *testing.T) {
+	desired := json.RawMessage(`{
+		"clientId": "user",
+		"defaultClientScopes": []
+	}`)
+	current := json.RawMessage(`{
+		"clientId": "user",
+		"defaultClientScopes": []
+	}`)
+
+	if !definitionsMatch(desired, current) {
+		t.Error("expected match: both empty scopes")
+	}
+}
+
+func TestDefinitionsMatch_AttributesSubset(t *testing.T) {
+	// CR defines a subset of attributes, Keycloak adds SAML defaults — should match
+	desired := json.RawMessage(`{
+		"clientId": "app",
+		"attributes": {"oauth2.device.authorization.grant.enabled": "false", "post.logout.redirect.uris": "+"}
+	}`)
+	current := json.RawMessage(`{
+		"clientId": "app",
+		"attributes": {"saml.assertion.signature": "false", "saml.force.post.binding": "false", "oauth2.device.authorization.grant.enabled": "false", "post.logout.redirect.uris": "+"}
+	}`)
+
+	if !definitionsMatch(desired, current) {
+		t.Error("expected match: CR attributes are a subset of Keycloak attributes")
+	}
+}
+
+func TestDefinitionsMatch_AttributeValueDiff(t *testing.T) {
+	desired := json.RawMessage(`{
+		"clientId": "app",
+		"attributes": {"oauth2.device.authorization.grant.enabled": "true"}
+	}`)
+	current := json.RawMessage(`{
+		"clientId": "app",
+		"attributes": {"oauth2.device.authorization.grant.enabled": "false"}
+	}`)
+
+	if definitionsMatch(desired, current) {
+		t.Error("expected no match: attribute value differs")
+	}
+}
+
+func TestDefinitionsMatch_ProtocolMappersSubset(t *testing.T) {
+	// CR defines protocolMappers without id/consentRequired, KC adds those fields
+	desired := json.RawMessage(`{
+		"clientId": "app",
+		"protocolMappers": [{"name": "test-mapper", "protocol": "openid-connect", "protocolMapper": "oidc-usermodel-attribute-mapper", "config": {"claim.name": "test"}}]
+	}`)
+	current := json.RawMessage(`{
+		"clientId": "app",
+		"protocolMappers": [{"id": "abc-123", "name": "test-mapper", "protocol": "openid-connect", "protocolMapper": "oidc-usermodel-attribute-mapper", "consentRequired": false, "config": {"claim.name": "test"}}]
+	}`)
+
+	if !definitionsMatch(desired, current) {
+		t.Error("expected match: CR protocolMapper is a subset of KC protocolMapper")
+	}
+}
+
+func TestDefinitionsMatch_SkipsDefaultClientScopes(t *testing.T) {
+	// defaultClientScopes are synced via dedicated API, so definitionsMatch should ignore them
+	desired := json.RawMessage(`{
+		"clientId": "user",
+		"defaultClientScopes": ["scope-a", "scope-b", "scope-c"],
+		"publicClient": false
+	}`)
+	current := json.RawMessage(`{
+		"clientId": "user",
+		"defaultClientScopes": ["scope-x"],
+		"publicClient": false
+	}`)
+
+	if !definitionsMatch(desired, current) {
+		t.Error("expected match: defaultClientScopes should be skipped in comparison")
+	}
+}
+
+func TestDefinitionsMatch_SkipsOptionalClientScopes(t *testing.T) {
+	desired := json.RawMessage(`{
+		"clientId": "user",
+		"optionalClientScopes": ["opt-a"],
+		"publicClient": true
+	}`)
+	current := json.RawMessage(`{
+		"clientId": "user",
+		"optionalClientScopes": [],
+		"publicClient": true
+	}`)
+
+	if !definitionsMatch(desired, current) {
+		t.Error("expected match: optionalClientScopes should be skipped in comparison")
+	}
+}

--- a/internal/controller/keycloakclient_controller_test.go
+++ b/internal/controller/keycloakclient_controller_test.go
@@ -162,3 +162,42 @@ func TestDefinitionsMatch_SkipsOptionalClientScopes(t *testing.T) {
 		t.Error("expected match: optionalClientScopes should be skipped in comparison")
 	}
 }
+
+func TestDefinitionsMatch_ProtocolMappersExtraInCurrent(t *testing.T) {
+	// Keycloak has an extra protocolMapper that the CR no longer declares.
+	// definitionsMatch must report drift so the PUT removes it.
+	desired := json.RawMessage(`{
+		"clientId": "app",
+		"protocolMappers": [{"name": "keep", "protocol": "openid-connect"}]
+	}`)
+	current := json.RawMessage(`{
+		"clientId": "app",
+		"protocolMappers": [
+			{"name": "keep", "protocol": "openid-connect"},
+			{"name": "orphan", "protocol": "openid-connect"}
+		]
+	}`)
+
+	if definitionsMatch(desired, current) {
+		t.Error("expected no match: orphan protocolMapper in current must surface as drift")
+	}
+}
+
+func TestDefinitionsMatch_ProtocolMappersExtraInDesired(t *testing.T) {
+	// CR adds a protocolMapper that Keycloak doesn't have yet — must surface as drift.
+	desired := json.RawMessage(`{
+		"clientId": "app",
+		"protocolMappers": [
+			{"name": "existing", "protocol": "openid-connect"},
+			{"name": "new-one", "protocol": "openid-connect"}
+		]
+	}`)
+	current := json.RawMessage(`{
+		"clientId": "app",
+		"protocolMappers": [{"name": "existing", "protocol": "openid-connect"}]
+	}`)
+
+	if definitionsMatch(desired, current) {
+		t.Error("expected no match: CR adds a protocolMapper that current lacks")
+	}
+}

--- a/internal/controller/keycloakidentityprovider_controller.go
+++ b/internal/controller/keycloakidentityprovider_controller.go
@@ -132,13 +132,26 @@ func (r *KeycloakIdentityProviderReconciler) Reconcile(ctx context.Context, req 
 		}
 		log.Info("identity provider created successfully", "alias", alias)
 	} else {
-		// Identity provider exists, update it
-		log.Info("updating identity provider", "alias", alias, "realm", realmName)
-		if err := kc.UpdateIdentityProvider(ctx, realmName, alias, definition); err != nil {
-			RecordError(controllerName, "keycloak_api_error")
-			return r.updateStatus(ctx, idp, false, "UpdateFailed", fmt.Sprintf("Failed to update identity provider: %v", err), alias)
+		// Identity provider exists — check if update is needed (drift-detection, pace patch)
+		// to avoid reconcile-storms where every 5-min sync triggers an unneeded PUT.
+		currentRaw, fetchErr := kc.GetIdentityProviderRaw(ctx, realmName, alias)
+		needsUpdate := true
+		if fetchErr != nil {
+			log.Error(fetchErr, "failed to fetch current IdP state, falling through to update")
+		} else if currentRaw != nil {
+			needsUpdate = !idpDefinitionsMatch(definition, currentRaw)
 		}
-		log.Info("identity provider updated successfully", "alias", alias)
+
+		if needsUpdate {
+			log.Info("updating identity provider", "alias", alias, "realm", realmName)
+			if err := kc.UpdateIdentityProvider(ctx, realmName, alias, definition); err != nil {
+				RecordError(controllerName, "keycloak_api_error")
+				return r.updateStatus(ctx, idp, false, "UpdateFailed", fmt.Sprintf("Failed to update identity provider: %v", err), alias)
+			}
+			log.Info("identity provider updated successfully", "alias", alias)
+		} else {
+			log.V(1).Info("identity provider already in sync, skipping update", "alias", alias)
+		}
 	}
 
 	// Update status

--- a/internal/controller/keycloakrealm_controller.go
+++ b/internal/controller/keycloakrealm_controller.go
@@ -143,29 +143,48 @@ func (r *KeycloakRealmReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			return result, nil
 		}
 	} else {
-		// Realm exists, update it - merge ID into definition
-		log.Info("updating realm", "realm", realmDef.Realm)
+		// Realm exists — check if update is needed (drift-detection)
 		definition = mergeIDIntoDefinition(definition, existingRealm.ID)
-		if err := kc.UpdateRealm(ctx, realmDef.Realm, definition); err != nil {
-			strippedDefinition, flowBindingsDeferred := stripRealmFlowBindingsForCreate(definition)
-			if !flowBindingsDeferred {
-				RecordError(controllerName, "keycloak_api_error")
-				return r.updateStatus(ctx, realm, false, "UpdateFailed", fmt.Sprintf("Failed to update realm: %v", err), instanceRef)
-			}
-			log.Info("realm update failed with authentication flow bindings; retrying without them", "realm", realmDef.Realm, "error", err)
-			if fallbackErr := kc.UpdateRealm(ctx, realmDef.Realm, strippedDefinition); fallbackErr != nil {
-				RecordError(controllerName, "keycloak_api_error")
-				return r.updateStatus(ctx, realm, false, "UpdateFailed", fmt.Sprintf("Failed to update realm: %v", err), instanceRef)
-			}
-			realm.Status.ResourcePath = fmt.Sprintf("/admin/realms/%s", realmDef.Realm)
-			result, statusErr := r.updateStatus(ctx, realm, true, "Ready", "Realm synchronized; authentication flow bindings will be retried after referenced flows exist", instanceRef)
-			if statusErr != nil {
-				return result, statusErr
-			}
-			result.RequeueAfter = ErrorRequeueDelay
-			return result, nil
+
+		// Fetch current state from Keycloak for drift detection
+		currentRaw, fetchErr := kc.GetRealmRaw(ctx, realmDef.Realm)
+
+		needsUpdate := true
+		if fetchErr != nil {
+			log.Error(fetchErr, "failed to fetch current realm state, falling through to update")
+		} else if currentRaw != nil {
+			needsUpdate = !definitionsMatch(definition, currentRaw)
 		}
-		log.Info("realm updated successfully", "realm", realmDef.Realm)
+
+		if needsUpdate {
+			log.Info("updating realm", "realm", realmDef.Realm)
+			if err := kc.UpdateRealm(ctx, realmDef.Realm, definition); err != nil {
+				// If the realm references authentication flows that don't exist yet
+				// (managed by separate KeycloakAuthenticationFlow CRs that haven't been
+				// reconciled), strip the flow-bindings and retry; mark the realm Ready
+				// so the flow CRs can reconcile, and requeue to re-bind later.
+				strippedDefinition, flowBindingsDeferred := stripRealmFlowBindingsForCreate(definition)
+				if !flowBindingsDeferred {
+					RecordError(controllerName, "keycloak_api_error")
+					return r.updateStatus(ctx, realm, false, "UpdateFailed", fmt.Sprintf("Failed to update realm: %v", err), instanceRef)
+				}
+				log.Info("realm update failed with authentication flow bindings; retrying without them", "realm", realmDef.Realm, "error", err)
+				if fallbackErr := kc.UpdateRealm(ctx, realmDef.Realm, strippedDefinition); fallbackErr != nil {
+					RecordError(controllerName, "keycloak_api_error")
+					return r.updateStatus(ctx, realm, false, "UpdateFailed", fmt.Sprintf("Failed to update realm: %v", err), instanceRef)
+				}
+				realm.Status.ResourcePath = fmt.Sprintf("/admin/realms/%s", realmDef.Realm)
+				result, statusErr := r.updateStatus(ctx, realm, true, "Ready", "Realm synchronized; authentication flow bindings will be retried after referenced flows exist", instanceRef)
+				if statusErr != nil {
+					return result, statusErr
+				}
+				result.RequeueAfter = ErrorRequeueDelay
+				return result, nil
+			}
+			log.Info("realm updated successfully", "realm", realmDef.Realm)
+		} else {
+			log.V(1).Info("realm already in sync, skipping update", "realm", realmDef.Realm)
+		}
 	}
 
 	// Update status
@@ -262,27 +281,52 @@ func (r *KeycloakRealmReconciler) deleteRealm(ctx context.Context, realm *keyclo
 }
 
 func (r *KeycloakRealmReconciler) updateStatus(ctx context.Context, realm *keycloakv1beta1.KeycloakRealm, ready bool, status, message string, instanceRef *keycloakv1beta1.InstanceRef) (ctrl.Result, error) {
+	desiredConditionStatus := metav1.ConditionFalse
+	if ready {
+		desiredConditionStatus = metav1.ConditionTrue
+	}
+
+	// Detect whether any user-visible status field actually changed
+	statusChanged := realm.Status.Ready != ready ||
+		realm.Status.Status != status ||
+		realm.Status.Message != message
+
+	conditionChanged := true
+	for _, c := range realm.Status.Conditions {
+		if c.Type == "Ready" && c.Status == desiredConditionStatus && c.Reason == status && c.Message == message {
+			conditionChanged = false
+			break
+		}
+	}
+
+	if !statusChanged && !conditionChanged {
+		// Nothing changed — skip the API write to avoid triggering a watch-event reconcile loop
+		if ready {
+			return ctrl.Result{RequeueAfter: GetSyncPeriod()}, nil
+		}
+		return ctrl.Result{RequeueAfter: ErrorRequeueDelay}, nil
+	}
+
 	realm.Status.Ready = ready
 	realm.Status.Status = status
 	realm.Status.Message = message
 	realm.Status.Instance = instanceRef
 
-	// Update conditions
 	condition := metav1.Condition{
 		Type:               "Ready",
-		Status:             metav1.ConditionFalse,
+		Status:             desiredConditionStatus,
 		Reason:             status,
 		Message:            message,
 		LastTransitionTime: metav1.Now(),
 	}
-	if ready {
-		condition.Status = metav1.ConditionTrue
-	}
 
-	// Update or add condition
 	found := false
 	for i, c := range realm.Status.Conditions {
 		if c.Type == "Ready" {
+			// Preserve LastTransitionTime if status did not flip
+			if c.Status == desiredConditionStatus {
+				condition.LastTransitionTime = c.LastTransitionTime
+			}
 			realm.Status.Conditions[i] = condition
 			found = true
 			break

--- a/internal/controller/keycloakrealm_controller.go
+++ b/internal/controller/keycloakrealm_controller.go
@@ -153,7 +153,7 @@ func (r *KeycloakRealmReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		if fetchErr != nil {
 			log.Error(fetchErr, "failed to fetch current realm state, falling through to update")
 		} else if currentRaw != nil {
-			needsUpdate = !definitionsMatch(definition, currentRaw)
+			needsUpdate = !realmDefinitionsMatch(definition, currentRaw)
 		}
 
 		if needsUpdate {

--- a/internal/controller/keycloakrolemapping_controller.go
+++ b/internal/controller/keycloakrolemapping_controller.go
@@ -120,28 +120,55 @@ func (r *KeycloakRoleMappingReconciler) Reconcile(ctx context.Context, req ctrl.
 		return r.updateStatus(ctx, mapping, false, "RoleNotFound", fmt.Sprintf("Failed to get role: %v", err), subjectType, subjectID, roleName, roleType)
 	}
 
-	// Apply the role mapping
-	roles := []keycloak.RoleRepresentation{*role}
-	if subjectType == "user" {
-		if roleType == "client" {
-			err = kc.AddClientRolesToUser(ctx, realmName, clientUUID, subjectID, roles)
-		} else {
-			err = kc.AddRealmRolesToUser(ctx, realmName, subjectID, roles)
+	// Check if role mapping already exists before applying
+	alreadyMapped := false
+	if role.ID != nil {
+		var existingRoles []keycloak.RoleRepresentation
+		var checkErr error
+		if subjectType == "user" {
+			if roleType == "client" {
+				existingRoles, checkErr = kc.GetUserClientRoleMappings(ctx, realmName, subjectID, clientUUID)
+			} else {
+				existingRoles, checkErr = kc.GetUserRealmRoleMappings(ctx, realmName, subjectID)
+			}
 		}
+		// For groups we skip the check and always apply (no GetGroupRoleMappings available)
+		if checkErr == nil && existingRoles != nil {
+			for _, er := range existingRoles {
+				if er.ID != nil && *er.ID == *role.ID {
+					alreadyMapped = true
+					break
+				}
+			}
+		}
+	}
+
+	if !alreadyMapped {
+		// Apply the role mapping
+		roles := []keycloak.RoleRepresentation{*role}
+		if subjectType == "user" {
+			if roleType == "client" {
+				err = kc.AddClientRolesToUser(ctx, realmName, clientUUID, subjectID, roles)
+			} else {
+				err = kc.AddRealmRolesToUser(ctx, realmName, subjectID, roles)
+			}
+		} else {
+			if roleType == "client" {
+				err = kc.AddClientRolesToGroup(ctx, realmName, clientUUID, subjectID, roles)
+			} else {
+				err = kc.AddRealmRolesToGroup(ctx, realmName, subjectID, roles)
+			}
+		}
+
+		if err != nil {
+			RecordError(controllerName, "keycloak_api_error")
+			return r.updateStatus(ctx, mapping, false, "MappingFailed", fmt.Sprintf("Failed to add role mapping: %v", err), subjectType, subjectID, roleName, roleType)
+		}
+
+		log.Info("role mapping applied", "subject", subjectType, "subjectID", subjectID, "role", roleName, "roleType", roleType)
 	} else {
-		if roleType == "client" {
-			err = kc.AddClientRolesToGroup(ctx, realmName, clientUUID, subjectID, roles)
-		} else {
-			err = kc.AddRealmRolesToGroup(ctx, realmName, subjectID, roles)
-		}
+		log.V(1).Info("role mapping already in sync, skipping", "subject", subjectType, "subjectID", subjectID, "role", roleName, "roleType", roleType)
 	}
-
-	if err != nil {
-		RecordError(controllerName, "keycloak_api_error")
-		return r.updateStatus(ctx, mapping, false, "MappingFailed", fmt.Sprintf("Failed to add role mapping: %v", err), subjectType, subjectID, roleName, roleType)
-	}
-
-	log.Info("role mapping applied", "subject", subjectType, "subjectID", subjectID, "role", roleName, "roleType", roleType)
 
 	// Update status with resource path
 	var resourcePath string
@@ -408,6 +435,24 @@ func (r *KeycloakRoleMappingReconciler) removeRoleMapping(ctx context.Context, m
 }
 
 func (r *KeycloakRoleMappingReconciler) updateStatus(ctx context.Context, mapping *keycloakv1beta1.KeycloakRoleMapping, ready bool, status, message, subjectType, subjectID, roleName, roleType string) (ctrl.Result, error) {
+	// Check if status actually changed
+	statusChanged := mapping.Status.Ready != ready ||
+		mapping.Status.Status != status ||
+		mapping.Status.Message != message ||
+		mapping.Status.SubjectType != subjectType ||
+		mapping.Status.SubjectID != subjectID ||
+		mapping.Status.RoleName != roleName ||
+		mapping.Status.RoleType != roleType
+
+	generationChanged := ready && mapping.Status.ObservedGeneration != mapping.Generation
+
+	if !statusChanged && !generationChanged {
+		if ready {
+			return ctrl.Result{RequeueAfter: GetSyncPeriod()}, nil
+		}
+		return ctrl.Result{RequeueAfter: ErrorRequeueDelay}, nil
+	}
+
 	mapping.Status.Ready = ready
 	mapping.Status.Status = status
 	mapping.Status.Message = message
@@ -416,7 +461,6 @@ func (r *KeycloakRoleMappingReconciler) updateStatus(ctx context.Context, mappin
 	mapping.Status.RoleName = roleName
 	mapping.Status.RoleType = roleType
 
-	// Track observed generation to detect spec changes
 	if ready {
 		mapping.Status.ObservedGeneration = mapping.Generation
 	}
@@ -431,7 +475,6 @@ func (r *KeycloakRoleMappingReconciler) updateStatus(ctx context.Context, mappin
 		return ctrl.Result{RequeueAfter: ErrorRequeueDelay}, nil
 	}
 
-	// Requeue after 5 minutes for periodic check
 	return ctrl.Result{RequeueAfter: GetSyncPeriod()}, nil
 }
 

--- a/internal/controller/keycloakrolemapping_controller.go
+++ b/internal/controller/keycloakrolemapping_controller.go
@@ -131,8 +131,13 @@ func (r *KeycloakRoleMappingReconciler) Reconcile(ctx context.Context, req ctrl.
 			} else {
 				existingRoles, checkErr = kc.GetUserRealmRoleMappings(ctx, realmName, subjectID)
 			}
+		} else {
+			if roleType == "client" {
+				existingRoles, checkErr = kc.GetGroupClientRoleMappings(ctx, realmName, subjectID, clientUUID)
+			} else {
+				existingRoles, checkErr = kc.GetGroupRealmRoleMappings(ctx, realmName, subjectID)
+			}
 		}
-		// For groups we skip the check and always apply (no GetGroupRoleMappings available)
 		if checkErr == nil && existingRoles != nil {
 			for _, er := range existingRoles {
 				if er.ID != nil && *er.ID == *role.ID {

--- a/internal/controller/keycloakuser_controller.go
+++ b/internal/controller/keycloakuser_controller.go
@@ -130,17 +130,31 @@ func (r *KeycloakUserReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		}
 		log.Info("user created successfully", "username", username, "id", userID)
 	} else {
-		// User exists, update it
+		// User exists — check if update is needed
 		existingUser := existingUsers[0]
 		userID = *existingUser.ID
 		definition = mergeIDIntoDefinition(definition, existingUser.ID)
 
-		log.Info("updating user", "username", username, "realm", realmName)
-		if err := kc.UpdateUser(ctx, realmName, userID, definition); err != nil {
-			RecordError(controllerName, "keycloak_api_error")
-			return r.updateStatus(ctx, user, false, "UpdateFailed", fmt.Sprintf("Failed to update user: %v", err), userID, false, "")
+		// Fetch current state for drift detection
+		currentRaw, fetchErr := kc.GetUserRaw(ctx, realmName, userID)
+
+		needsUpdate := true
+		if fetchErr != nil {
+			log.Error(fetchErr, "failed to fetch current user state, falling through to update")
+		} else if currentRaw != nil {
+			needsUpdate = !definitionsMatch(definition, currentRaw)
 		}
-		log.Info("user updated successfully", "username", username)
+
+		if needsUpdate {
+			log.Info("updating user", "username", username, "realm", realmName)
+			if err := kc.UpdateUser(ctx, realmName, userID, definition); err != nil {
+				RecordError(controllerName, "keycloak_api_error")
+				return r.updateStatus(ctx, user, false, "UpdateFailed", fmt.Sprintf("Failed to update user: %v", err), userID, false, "")
+			}
+			log.Info("user updated successfully", "username", username)
+		} else {
+			log.V(1).Info("user already in sync, skipping update", "username", username)
+		}
 	}
 
 	// Handle initial password if specified
@@ -427,6 +441,37 @@ func (r *KeycloakUserReconciler) getKeycloakClientAndRealmFromClient(ctx context
 }
 
 func (r *KeycloakUserReconciler) updateStatus(ctx context.Context, user *keycloakv1beta1.KeycloakUser, ready bool, status, message, userID string, isServiceAccount bool, clientID string) (ctrl.Result, error) {
+	// Determine desired condition status
+	desiredConditionStatus := metav1.ConditionFalse
+	if ready {
+		desiredConditionStatus = metav1.ConditionTrue
+	}
+
+	// Check if status actually changed
+	statusChanged := user.Status.Ready != ready ||
+		user.Status.Status != status ||
+		user.Status.Message != message ||
+		user.Status.IsServiceAccount != isServiceAccount ||
+		user.Status.ClientID != clientID ||
+		(userID != "" && user.Status.UserID != userID)
+
+	conditionChanged := true
+	for _, c := range user.Status.Conditions {
+		if c.Type == "Ready" && c.Status == desiredConditionStatus && c.Reason == status && c.Message == message {
+			conditionChanged = false
+			break
+		}
+	}
+
+	generationChanged := ready && user.Status.ObservedGeneration != user.Generation
+
+	if !statusChanged && !conditionChanged && !generationChanged {
+		if ready {
+			return ctrl.Result{RequeueAfter: GetSyncPeriod()}, nil
+		}
+		return ctrl.Result{RequeueAfter: ErrorRequeueDelay}, nil
+	}
+
 	user.Status.Ready = ready
 	user.Status.Status = status
 	user.Status.Message = message
@@ -436,26 +481,24 @@ func (r *KeycloakUserReconciler) updateStatus(ctx context.Context, user *keycloa
 	user.Status.IsServiceAccount = isServiceAccount
 	user.Status.ClientID = clientID
 
-	// Track observed generation to detect spec changes
 	if ready {
 		user.Status.ObservedGeneration = user.Generation
 	}
 
-	// Update conditions
 	condition := metav1.Condition{
 		Type:               "Ready",
-		Status:             metav1.ConditionFalse,
+		Status:             desiredConditionStatus,
 		Reason:             status,
 		Message:            message,
 		LastTransitionTime: metav1.Now(),
-	}
-	if ready {
-		condition.Status = metav1.ConditionTrue
 	}
 
 	found := false
 	for i, c := range user.Status.Conditions {
 		if c.Type == "Ready" {
+			if c.Status == desiredConditionStatus {
+				condition.LastTransitionTime = c.LastTransitionTime
+			}
 			user.Status.Conditions[i] = condition
 			found = true
 			break

--- a/test/e2e/drift_skip_test.go
+++ b/test/e2e/drift_skip_test.go
@@ -1,0 +1,361 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	keycloakv1beta1 "github.com/Hostzero-GmbH/keycloak-operator/api/v1beta1"
+)
+
+// TestDriftSkip verifies that controllers gated by definitionsMatch skip the
+// PUT to Keycloak when the desired state already matches what's stored. The
+// three sub-tests cover the comparator paths most likely to silently regress:
+//
+//   - Unordered string-array equality on a real KeycloakClient with reordered
+//     redirectUris (set-equality path of valuesMatch).
+//   - The IdP clientSecret mask wrapper (idpDefinitionsMatch). This is the
+//     scenario the original drift loop hit hardest: every reconcile pushes
+//     the secret, Keycloak masks it on GET, so naive byte-compare always
+//     fires drift.
+//   - The realm smtpServer.password mask wrapper (realmDefinitionsMatch),
+//     same shape as the IdP case but on KeycloakRealm.
+//
+// All three assertions rely on the operator's V(1) "already in sync, skipping
+// update" log line as direct evidence the comparator returned true and the
+// PUT was bypassed. The chart's dev values run zap with development:true, so
+// debug-level controller-runtime logs reach the pod stdout.
+func TestDriftSkip(t *testing.T) {
+	skipIfNoCluster(t)
+	skipIfNoKeycloakAccess(t)
+
+	instanceName, instanceNS := getOrCreateInstance(t)
+
+	t.Run("KeycloakClient_UnorderedRedirectUrisSkipsUpdate", func(t *testing.T) {
+		realmName := createTestRealm(t, instanceName, instanceNS, "drift-client")
+
+		clientName := fmt.Sprintf("drift-client-%d", time.Now().UnixNano())
+		clientDef := rawJSON(fmt.Sprintf(`{
+			"clientId": "%s",
+			"enabled": true,
+			"publicClient": true,
+			"redirectUris": ["https://a.example.com/*", "https://b.example.com/*", "https://c.example.com/*"],
+			"webOrigins": ["https://a.example.com", "https://b.example.com"]
+		}`, clientName))
+
+		kcClient := &keycloakv1beta1.KeycloakClient{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clientName,
+				Namespace: testNamespace,
+			},
+			Spec: keycloakv1beta1.KeycloakClientSpec{
+				RealmRef:   &keycloakv1beta1.ResourceRef{Name: realmName},
+				Definition: &clientDef,
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, kcClient))
+		t.Cleanup(func() { k8sClient.Delete(ctx, kcClient) })
+
+		waitForKCClientReady(t, kcClient.Name, kcClient.Namespace)
+
+		updated := &keycloakv1beta1.KeycloakClient{}
+		require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: kcClient.Name, Namespace: kcClient.Namespace}, updated))
+		require.NotEmpty(t, updated.Status.ClientUUID)
+
+		// Trigger a forced reconcile by patching an annotation. The CR spec
+		// hasn't changed and Keycloak still has the same redirectUris the
+		// controller pushed at create time, so definitionsMatch must report
+		// equality and the controller must skip UpdateClient.
+		since := time.Now().UTC()
+		bumpReconcile(t, updated)
+
+		assertSkipLogged(t, since, "client already in sync, skipping update", "clientId", clientName)
+
+		// Sanity check: status stayed Ready, ObservedGeneration tracks Generation.
+		final := &keycloakv1beta1.KeycloakClient{}
+		require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: kcClient.Name, Namespace: kcClient.Namespace}, final))
+		require.True(t, final.Status.Ready, "client should remain Ready after skipped reconcile")
+		require.Equal(t, final.Generation, final.Status.ObservedGeneration, "ObservedGeneration should track Generation")
+	})
+
+	t.Run("KeycloakIdentityProvider_SecretMaskNoLoop", func(t *testing.T) {
+		realmName := createTestRealm(t, instanceName, instanceNS, "drift-idp")
+
+		idpName := fmt.Sprintf("drift-idp-%d", time.Now().UnixNano())
+
+		// configSecretRef supplies the real clientSecret. Keycloak masks it
+		// on GET as "**********", which is the exact case idpDefinitionsMatch
+		// strips from both sides.
+		idpSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      idpName + "-cfg",
+				Namespace: testNamespace,
+			},
+			StringData: map[string]string{
+				"clientId":     "drift-client-id",
+				"clientSecret": "drift-client-secret-value",
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, idpSecret))
+		t.Cleanup(func() { k8sClient.Delete(ctx, idpSecret) })
+
+		idpDef := rawJSON(fmt.Sprintf(`{
+			"alias": "%s",
+			"providerId": "oidc",
+			"enabled": true,
+			"config": {
+				"authorizationUrl": "https://idp.example.com/auth",
+				"tokenUrl": "https://idp.example.com/token",
+				"defaultScope": "openid"
+			}
+		}`, idpName))
+
+		idp := &keycloakv1beta1.KeycloakIdentityProvider{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      idpName,
+				Namespace: testNamespace,
+			},
+			Spec: keycloakv1beta1.KeycloakIdentityProviderSpec{
+				RealmRef:        &keycloakv1beta1.ResourceRef{Name: realmName},
+				ConfigSecretRef: &keycloakv1beta1.IDPConfigSecretRef{Name: idpSecret.Name},
+				Definition:      idpDef,
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, idp))
+		t.Cleanup(func() { k8sClient.Delete(ctx, idp) })
+
+		waitForIDPReady(t, idp.Name, idp.Namespace)
+
+		// Confirm Keycloak is masking clientSecret as expected — that's what
+		// drives the masking branch in idpDefinitionsMatch. If Keycloak ever
+		// changes the mask string, this assertion fails fast and tells us.
+		kc := getInternalKeycloakClient(t)
+		raw, err := kc.GetIdentityProviderRaw(ctx, realmName, idpName)
+		require.NoError(t, err)
+		var idpMap map[string]interface{}
+		require.NoError(t, json.Unmarshal(raw, &idpMap))
+		cfg, _ := idpMap["config"].(map[string]interface{})
+		require.NotNil(t, cfg, "config map missing on IdP read-back")
+		require.Equal(t, "**********", cfg["clientSecret"],
+			"Keycloak no longer masks IdP clientSecret as **********; idpDefinitionsMatch needs revisiting")
+
+		// Force a reconcile and assert the controller logs the skip line.
+		// Without idpDefinitionsMatch, current would carry "**********" while
+		// desired carries the real secret, so naive comparison would fire
+		// drift and PUT every reconcile (the original bug).
+		updated := &keycloakv1beta1.KeycloakIdentityProvider{}
+		require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: idp.Name, Namespace: idp.Namespace}, updated))
+
+		since := time.Now().UTC()
+		bumpReconcile(t, updated)
+
+		assertSkipLogged(t, since, "identity provider already in sync, skipping update", "alias", idpName)
+
+		final := &keycloakv1beta1.KeycloakIdentityProvider{}
+		require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: idp.Name, Namespace: idp.Namespace}, final))
+		require.True(t, final.Status.Ready, "IdP should remain Ready after skipped reconcile")
+	})
+
+	t.Run("KeycloakRealm_SmtpSecretMaskNoLoop", func(t *testing.T) {
+		realmName := fmt.Sprintf("drift-smtp-realm-%d", time.Now().UnixNano())
+
+		smtpSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      realmName + "-smtp",
+				Namespace: testNamespace,
+			},
+			StringData: map[string]string{
+				"user":     "drift-smtp@example.com",
+				"password": "drift-smtp-password",
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, smtpSecret))
+		t.Cleanup(func() { k8sClient.Delete(ctx, smtpSecret) })
+
+		realm := &keycloakv1beta1.KeycloakRealm{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      realmName,
+				Namespace: testNamespace,
+			},
+			Spec: keycloakv1beta1.KeycloakRealmSpec{
+				InstanceRef:   &keycloakv1beta1.ResourceRef{Name: instanceName, Namespace: &instanceNS},
+				SmtpSecretRef: &keycloakv1beta1.SmtpSecretRefSpec{Name: smtpSecret.Name},
+				Definition: rawJSON(fmt.Sprintf(`{
+					"realm": "%s",
+					"enabled": true,
+					"smtpServer": {
+						"host": "smtp.example.com",
+						"port": "587",
+						"auth": "true"
+					}
+				}`, realmName)),
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, realm))
+		t.Cleanup(func() { k8sClient.Delete(ctx, realm) })
+
+		waitForRealmReady(t, realm.Name, realm.Namespace)
+
+		// Verify Keycloak is masking smtpServer.password (what realmDefinitionsMatch
+		// keys off). Same fail-fast intent as the IdP test.
+		kc := getInternalKeycloakClient(t)
+		raw, err := kc.GetRealmRaw(ctx, realmName)
+		require.NoError(t, err)
+		var realmMap map[string]interface{}
+		require.NoError(t, json.Unmarshal(raw, &realmMap))
+		smtp, _ := realmMap["smtpServer"].(map[string]interface{})
+		require.NotNil(t, smtp, "smtpServer map missing on realm read-back")
+		require.Equal(t, "**********", smtp["password"],
+			"Keycloak no longer masks smtpServer.password as **********; realmDefinitionsMatch needs revisiting")
+
+		updated := &keycloakv1beta1.KeycloakRealm{}
+		require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: realm.Name, Namespace: realm.Namespace}, updated))
+
+		since := time.Now().UTC()
+		bumpReconcile(t, updated)
+
+		assertSkipLogged(t, since, "realm already in sync, skipping update", "realm", realmName)
+
+		final := &keycloakv1beta1.KeycloakRealm{}
+		require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: realm.Name, Namespace: realm.Namespace}, final))
+		require.True(t, final.Status.Ready, "realm should remain Ready after skipped reconcile")
+	})
+}
+
+// bumpReconcile patches an annotation onto the given object to force the
+// controller's For() watch to fire a reconcile event. Spec generation is
+// unchanged because annotations live on metadata, so observed-generation
+// tracking is unaffected. Returns once the watch event has had a chance
+// to fire (caller is expected to assert behaviour afterwards).
+func bumpReconcile(t *testing.T, obj client.Object) {
+	t.Helper()
+	annos := obj.GetAnnotations()
+	if annos == nil {
+		annos = map[string]string{}
+	}
+	annos["test/drift-skip-trigger"] = fmt.Sprintf("%d", time.Now().UnixNano())
+	obj.SetAnnotations(annos)
+	require.NoError(t, k8sClient.Update(ctx, obj))
+	// Give the controller-runtime workqueue a moment to process the event.
+	// 3s comfortably covers a no-op reconcile (Get+definitionsMatch+log+
+	// status update with no Keycloak PUT) on the kind cluster.
+	time.Sleep(3 * time.Second)
+}
+
+// assertSkipLogged tails the operator pod logs since `since` and asserts the
+// expected V(1) "already in sync, skipping update" line was emitted with the
+// expected structured field (e.g. clientId="foo", alias="bar"). Polls for up
+// to 30s because the operator's stdout buffering plus kubectl's --since-time
+// rounding can briefly hide a log line that's already been written.
+func assertSkipLogged(t *testing.T, since time.Time, msg, kvKey, kvValue string) {
+	t.Helper()
+	operatorNS := os.Getenv("OPERATOR_NAMESPACE")
+	if operatorNS == "" {
+		operatorNS = "keycloak-operator"
+	}
+	// kubectl logs --since-time is RFC3339 with second precision; round down
+	// one second so we don't accidentally crop the line we're looking for.
+	sinceFlag := since.Add(-1 * time.Second).Format(time.RFC3339)
+
+	deadline := time.Now().Add(30 * time.Second)
+	var lastOut string
+	for time.Now().Before(deadline) {
+		out, err := exec.Command(
+			"kubectl", "logs",
+			"-n", operatorNS,
+			"-l", "app.kubernetes.io/name=keycloak-operator",
+			"--since-time="+sinceFlag,
+			"--tail=2000",
+		).CombinedOutput()
+		if err == nil {
+			lastOut = string(out)
+			if logsContainSkip(lastOut, msg, kvKey, kvValue) {
+				t.Logf("Drift-skip log observed: %q with %s=%q", msg, kvKey, kvValue)
+				return
+			}
+		}
+		time.Sleep(1 * time.Second)
+	}
+
+	// Dump the captured tail to make a failure debuggable without re-running.
+	t.Fatalf(
+		"expected operator log line %q with %s=%q since %s, but no matching line found.\n--- last operator log tail ---\n%s",
+		msg, kvKey, kvValue, sinceFlag, truncateForLog(lastOut, 4000),
+	)
+}
+
+// logsContainSkip walks the operator log line-by-line looking for one that
+// contains both the message and the structured kv pair. zap dev format emits
+// the message as plain text and the structured fields as a trailing JSON
+// object, e.g.:
+//
+//	2026-...  DEBUG  ... client already in sync, skipping update {"clientId": "foo", ...}
+//
+// so a substring check is sufficient and resilient to field reordering.
+func logsContainSkip(logs, msg, kvKey, kvValue string) bool {
+	kvNeedle := fmt.Sprintf(`"%s": "%s"`, kvKey, kvValue)
+	for _, line := range strings.Split(logs, "\n") {
+		if strings.Contains(line, msg) && strings.Contains(line, kvNeedle) {
+			return true
+		}
+	}
+	return false
+}
+
+func truncateForLog(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return "...[truncated " + fmt.Sprint(len(s)-n) + " bytes]...\n" + s[len(s)-n:]
+}
+
+// waitForKCClientReady waits for a KeycloakClient to reach Ready status.
+func waitForKCClientReady(t *testing.T, name, namespace string) {
+	t.Helper()
+	err := wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+		updated := &keycloakv1beta1.KeycloakClient{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, updated); err != nil {
+			return false, nil
+		}
+		return updated.Status.Ready, nil
+	})
+	require.NoError(t, err, "KeycloakClient %s/%s did not become ready", namespace, name)
+}
+
+// waitForIDPReady waits for a KeycloakIdentityProvider to reach Ready status.
+func waitForIDPReady(t *testing.T, name, namespace string) {
+	t.Helper()
+	err := wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+		updated := &keycloakv1beta1.KeycloakIdentityProvider{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, updated); err != nil {
+			return false, nil
+		}
+		return updated.Status.Ready, nil
+	})
+	require.NoError(t, err, "KeycloakIdentityProvider %s/%s did not become ready", namespace, name)
+}
+
+// waitForRealmReady waits for a KeycloakRealm to reach Ready status.
+func waitForRealmReady(t *testing.T, name, namespace string) {
+	t.Helper()
+	err := wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+		updated := &keycloakv1beta1.KeycloakRealm{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, updated); err != nil {
+			return false, nil
+		}
+		return updated.Status.Ready, nil
+	})
+	require.NoError(t, err, "KeycloakRealm %s/%s did not become ready", namespace, name)
+}


### PR DESCRIPTION
## Problem

Every controller in the operator (`KeycloakClient`, `KeycloakRealm`, `ClusterKeycloakRealm`, `KeycloakUser`, `KeycloakRoleMapping`, `KeycloakIdentityProvider`) calls its respective `Update…` API unconditionally on every reconcile, even when the desired definition exactly matches what's already in Keycloak.

In our environment with realms holding ~120 clients, dozens of users, and several IdPs, this produced roughly _100 PUTs per 5-minute sync cycle_ on otherwise-quiescent resources, driving load on Keycloak and saturating the controller workqueue. Three properties of Keycloak's API made naive `bytes.Equal` comparisons useless:

1. **String arrays come back unordered** — `redirectUris`, `defaultClientScopes`, `webOrigins`, etc. are returned in HashMap iteration order, so a re-encoded CR almost never matches by string.
2. **Maps carry Keycloak-added defaults** — `attributes` on clients/realms picks up SAML keys, lifecycle keys, etc. that the CR doesn't (and shouldn't) set.
3. **`config.clientSecret` on IdPs is masked** — GET returns the literal string `"**********"`, so a fresh CR with the real secret looks like drift on every reconcile.

## Solution

Add a shared `definitionsMatch(desired, current json.RawMessage) bool` helper plus a `valuesMatch` recursive comparator in `internal/controller`, with three comparison rules:

- **String arrays** are treated as unordered sets — sorted, then compared element-wise.
- **Maps / objects** use _subset_ comparison — every key in `desired` must match `current`, but extra Keycloak-added keys are tolerated.
- **Arrays of objects** (e.g. `protocolMappers`, `authenticationFlowBindingOverrides`) are matched by their `name` field and then subset-compared element-by-element.

Before each `Update…` call, the controller fetches the current state from Keycloak (`GetClientRaw`, `GetRealmRaw`, `GetUserRaw`, `GetClientRoleMappings`, `GetIdentityProviderRaw`) and skips the PUT when `definitionsMatch` reports equality.

### Controller-specific touches

- **KeycloakClient** — `defaultClientScopes` and `optionalClientScopes` are skipped by the comparator because they are already synced via dedicated endpoints (introduced in PR #52). Without the skip, scope drift would always force a PUT that the dedicated endpoints would then undo.
- **KeycloakRealm / ClusterKeycloakRealm** — drift-detection wraps around the existing authentication-flow-binding fallback (the strip-bindings-and-retry path). The fallback only fires when the PUT itself fails; the drift check decides whether the PUT happens at all, so the two compose cleanly.
- **KeycloakIdentityProvider** — gets a small wrapper `idpDefinitionsMatch` that, _only when current `config.clientSecret == "**********"`_, drops the field from both sides before calling `definitionsMatch`. The mask is Keycloak's signal that "I have a value, I just won't tell you which" — that's safe to ignore. Any other value (including `null` on a freshly-created IdP) is left intact so the diff fires and the secret gets pushed. First reconcile after `configSecretRef` is set therefore sees `null` in current → diff → PUT (Keycloak masks on next GET) → subsequent reconciles see the mask → skip.

## Tests

- New unit tests in `keycloakclient_controller_test.go` covering each comparator branch: unordered scopes, unordered `redirectUris`, scalar diffs, extra-fields-ignored, attributes subset, attribute-value diff, protocol-mapper subset, skip-defaultClientScopes, skip-optionalClientScopes.
- Existing controller and integration tests still pass.

## Verification in production-shaped environment

Observed across ~124 KeycloakClient CRs, 3 realms, 1 IdP per realm:

- Before: ~100/124 client PUTs per 5-minute reconcile cycle, realm PUTs every cycle, IdP PUT every cycle.
- After: only resources whose CR genuinely changed receive a PUT. No reconcile-storm on the IdP after `configSecretRef` is wired up — first reconcile pushes the secret, every reconcile after that skips cleanly.

## Diff summary

8 files, +672 / -85:

- `internal/controller/keycloakclient_controller.go` — comparator helpers + integration
- `internal/controller/keycloakclient_controller_test.go` — new
- `internal/controller/keycloakrealm_controller.go`
- `internal/controller/clusterkeycloakrealm_controller.go`
- `internal/controller/keycloakuser_controller.go`
- `internal/controller/keycloakrolemapping_controller.go`
- `internal/controller/keycloakidentityprovider_controller.go`
- `internal/controller/keycloak_config.go` — `idpDefinitionsMatch` helper
