### PR TITLE
Materialize Kubernetes Secret with client-id for public KeycloakClients

### DIFF
--- a/api/v1beta1/keycloakclient_types.go
+++ b/api/v1beta1/keycloakclient_types.go
@@ -29,6 +29,9 @@ type KeycloakClientSpec struct {
 	// ClientSecretRef configures the Kubernetes Secret for client credentials.
 	// If the secret exists, its value is used. If it doesn't exist and Create is true,
 	// the operator auto-generates a secret and creates it.
+	// For public clients (publicClient: true) the Secret is still materialised
+	// when ClientSecretRef is set, but only contains the client-id key — there
+	// is no client_secret to store.
 	// +optional
 	ClientSecretRef *ClientSecretRefSpec `json:"clientSecretRef,omitempty"`
 }
@@ -36,6 +39,7 @@ type KeycloakClientSpec struct {
 // ClientSecretRefSpec references a Kubernetes Secret for the client credentials.
 // If the secret exists, its value is used. If it doesn't exist and Create is true,
 // the operator auto-generates a secret and creates it.
+// For public clients the Secret will only contain the client-id key.
 type ClientSecretRefSpec struct {
 	// Name of the Kubernetes Secret
 	// +kubebuilder:validation:Required

--- a/charts/keycloak-operator/files/crds/keycloak.hostzero.com_keycloakclients.yaml
+++ b/charts/keycloak-operator/files/crds/keycloak.hostzero.com_keycloakclients.yaml
@@ -64,6 +64,9 @@ spec:
                   ClientSecretRef configures the Kubernetes Secret for client credentials.
                   If the secret exists, its value is used. If it doesn't exist and Create is true,
                   the operator auto-generates a secret and creates it.
+                  For public clients (publicClient: true) the Secret is still materialised
+                  when ClientSecretRef is set, but only contains the client-id key — there
+                  is no client_secret to store.
                 properties:
                   clientIdKey:
                     description: |-

--- a/config/crd/bases/keycloak.hostzero.com_keycloakclients.yaml
+++ b/config/crd/bases/keycloak.hostzero.com_keycloakclients.yaml
@@ -64,6 +64,9 @@ spec:
                   ClientSecretRef configures the Kubernetes Secret for client credentials.
                   If the secret exists, its value is used. If it doesn't exist and Create is true,
                   the operator auto-generates a secret and creates it.
+                  For public clients (publicClient: true) the Secret is still materialised
+                  when ClientSecretRef is set, but only contains the client-id key — there
+                  is no client_secret to store.
                 properties:
                   clientIdKey:
                     description: |-

--- a/docs/src/crds/keycloakclient.md
+++ b/docs/src/crds/keycloakclient.md
@@ -75,6 +75,7 @@ The `clientSecretRef` field controls how client secrets are managed:
 - **If the secret exists**: The operator reads the client secret from the specified key and configures Keycloak to use it.
 - **If the secret doesn't exist and `create: true`**: The operator lets Keycloak auto-generate a secret and creates the Kubernetes Secret.
 - **If the secret doesn't exist and `create: false`**: The operator reports an error (strict mode for GitOps workflows).
+- **Public clients (`publicClient: true`)**: When `clientSecretRef` is set, the Secret is still materialized but only contains the `client-id` key — public OAuth clients have no `client_secret` to store. This lets consumer charts pull the client ID via `envFrom` or `secretKeyRef` regardless of whether the client is public or confidential. If `clientSecretRef` is not set, no Secret is created.
 
 ### Use Cases
 
@@ -124,6 +125,11 @@ spec:
       - https://my-app.example.com/*
     webOrigins:
       - https://my-app.example.com
+  # Optional: still materialise a Secret so consumers can mount the
+  # client-id via envFrom. The Secret will only contain the client-id
+  # key — public clients have no client_secret.
+  clientSecretRef:
+    name: my-spa-credentials
 ```
 
 ### Confidential Client (Backend)
@@ -203,7 +209,7 @@ spec:
 
 ## Generated Secret Format
 
-When the operator creates or manages a secret, it has this structure:
+When the operator creates or manages a secret for a **confidential client**, it has this structure:
 
 ```yaml
 apiVersion: v1
@@ -218,6 +224,22 @@ type: Opaque
 data:
   client-id: bXktYXBw          # base64 encoded
   client-secret: c2VjcmV0...   # base64 encoded
+```
+
+For a **public client** (`publicClient: true`) the Secret is materialized with only the `client-id` key, since there is no OAuth `client_secret`:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-spa-credentials
+  ownerReferences:
+    - apiVersion: keycloak.hostzero.com/v1beta1
+      kind: KeycloakClient
+      name: my-spa
+type: Opaque
+data:
+  client-id: bXktc3Bh          # base64 encoded
 ```
 
 ## Authentication Flow Binding Overrides

--- a/internal/controller/keycloakclient_controller.go
+++ b/internal/controller/keycloakclient_controller.go
@@ -366,9 +366,10 @@ func (r *KeycloakClientReconciler) getKeycloakClientFromClusterRealm(ctx context
 // ensureClientSecret reads or creates the client secret.
 // Returns: (secretValue, needsCreation, error)
 // - If secret exists with the key: returns (value, false, nil)
+// - If secret exists but key is missing and the client is public: returns ("", false, nil)
+// - If secret exists but key is missing on a non-public client: returns ("", false, error)
 // - If secret doesn't exist and create=true: returns ("", true, nil) - will be created after Keycloak generates
 // - If secret doesn't exist and create=false: returns ("", false, error)
-// - If secret exists but key is missing: returns ("", false, error)
 func (r *KeycloakClientReconciler) ensureClientSecret(ctx context.Context, kcClient *keycloakv1beta1.KeycloakClient) (string, bool, error) {
 	ref := kcClient.Spec.ClientSecretRef
 	secretName := ref.Name
@@ -388,6 +389,12 @@ func (r *KeycloakClientReconciler) ensureClientSecret(ctx context.Context, kcCli
 		// Secret exists - read the value
 		value, ok := secret.Data[secretKey]
 		if !ok {
+			// Public clients legitimately have no client-secret key; the Secret
+			// is only used as a holder for the client-id. Treat the missing key
+			// as "no pre-existing secret to inject" rather than an error.
+			if isPublicClient(kcClient) {
+				return "", false, nil
+			}
 			return "", false, fmt.Errorf("key %q not found in secret %q", secretKey, secretName)
 		}
 		return string(value), false, nil
@@ -407,15 +414,30 @@ func (r *KeycloakClientReconciler) ensureClientSecret(ctx context.Context, kcCli
 	return "", true, nil
 }
 
+// isPublicClient reports whether the KeycloakClient spec marks the client as
+// public. A public client has no OAuth client_secret, so the K8s Secret will
+// only carry the client-id key.
+func isPublicClient(kcClient *keycloakv1beta1.KeycloakClient) bool {
+	if kcClient.Spec.Definition == nil || len(kcClient.Spec.Definition.Raw) == 0 {
+		return false
+	}
+	var parsed struct {
+		PublicClient *bool `json:"publicClient"`
+	}
+	if err := json.Unmarshal(kcClient.Spec.Definition.Raw, &parsed); err != nil {
+		return false
+	}
+	return parsed.PublicClient != nil && *parsed.PublicClient
+}
+
 func (r *KeycloakClientReconciler) syncClientSecret(ctx context.Context, kcClient *keycloakv1beta1.KeycloakClient, kc *keycloak.Client, realmName, clientUUID string) error {
-	// Get client secret from Keycloak
+	// Get client secret from Keycloak. For public clients this returns an empty
+	// string — we still want to materialise a Secret so consumers can pick up
+	// the client-id via envFrom/secretKeyRef, matching the legacy operator's
+	// behaviour.
 	secretValue, err := kc.GetClientSecret(ctx, realmName, clientUUID)
 	if err != nil {
 		return fmt.Errorf("failed to get client secret: %w", err)
-	}
-
-	if secretValue == "" {
-		return nil // No secret (public client)
 	}
 
 	// Get clientId from spec or definition
@@ -457,7 +479,10 @@ func (r *KeycloakClientReconciler) syncClientSecret(ctx context.Context, kcClien
 		// Reset data to ensure only the specified keys exist
 		secret.Data = make(map[string][]byte)
 		secret.Data[clientIdKey] = []byte(clientId)
-		secret.Data[clientSecretKey] = []byte(secretValue)
+		// Only emit the client-secret key when Keycloak returned one (i.e. confidential client).
+		if secretValue != "" {
+			secret.Data[clientSecretKey] = []byte(secretValue)
+		}
 		secret.Type = corev1.SecretTypeOpaque
 		return controllerutil.SetControllerReference(kcClient, secret, r.Scheme)
 	})

--- a/internal/controller/keycloakclient_controller_test.go
+++ b/internal/controller/keycloakclient_controller_test.go
@@ -3,6 +3,10 @@ package controller
 import (
 	"encoding/json"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	keycloakv1beta1 "github.com/Hostzero-GmbH/keycloak-operator/api/v1beta1"
 )
 
 func TestDefinitionsMatch_ScopesUnordered(t *testing.T) {
@@ -199,5 +203,37 @@ func TestDefinitionsMatch_ProtocolMappersExtraInDesired(t *testing.T) {
 
 	if definitionsMatch(desired, current) {
 		t.Error("expected no match: CR adds a protocolMapper that current lacks")
+	}
+}
+
+func TestIsPublicClient(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want bool
+	}{
+		{name: "public", raw: `{"clientId":"app","publicClient":true}`, want: true},
+		{name: "explicit confidential", raw: `{"clientId":"app","publicClient":false}`, want: false},
+		{name: "field absent", raw: `{"clientId":"app"}`, want: false},
+		{name: "definition empty", raw: ``, want: false},
+		{name: "definition garbage", raw: `not json`, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			kc := &keycloakv1beta1.KeycloakClient{}
+			if tc.raw != "" {
+				kc.Spec.Definition = &runtime.RawExtension{Raw: []byte(tc.raw)}
+			}
+			if got := isPublicClient(kc); got != tc.want {
+				t.Errorf("isPublicClient(%q) = %v, want %v", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsPublicClient_NilSpec(t *testing.T) {
+	kc := &keycloakv1beta1.KeycloakClient{}
+	if isPublicClient(kc) {
+		t.Error("expected false for nil Definition")
 	}
 }

--- a/internal/controller/keycloakclient_controller_test.go
+++ b/internal/controller/keycloakclient_controller_test.go
@@ -237,3 +237,25 @@ func TestIsPublicClient_NilSpec(t *testing.T) {
 		t.Error("expected false for nil Definition")
 	}
 }
+
+func TestIsPublicClient_EmptyRaw(t *testing.T) {
+	// Definition is non-nil but Raw is empty — exercises the
+	// len(kcClient.Spec.Definition.Raw) == 0 branch that the table-driven
+	// "definition empty" case skips (since it leaves Definition nil).
+	cases := []struct {
+		name string
+		raw  []byte
+	}{
+		{name: "nil raw", raw: nil},
+		{name: "empty raw", raw: []byte{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			kc := &keycloakv1beta1.KeycloakClient{}
+			kc.Spec.Definition = &runtime.RawExtension{Raw: tc.raw}
+			if isPublicClient(kc) {
+				t.Errorf("expected false for non-nil Definition with %s", tc.name)
+			}
+		})
+	}
+}

--- a/test/e2e/client_test.go
+++ b/test/e2e/client_test.go
@@ -138,6 +138,70 @@ func TestKeycloakClientE2E(t *testing.T) {
 		t.Log("Verified: No secret created for public client")
 	})
 
+	t.Run("PublicClientWithSecretRef", func(t *testing.T) {
+		// Public client that opts in to a Secret via ClientSecretRef. The
+		// Secret should be materialised but only carry the client-id key —
+		// public clients have no client_secret. Matches the legacy operator
+		// behaviour relied on by consumers using envFrom: secretRef for the
+		// client-id.
+		clientName := fmt.Sprintf("public-client-secref-%d", time.Now().UnixNano())
+		clientDef := rawJSON(fmt.Sprintf(`{
+			"clientId": "%s",
+			"name": "Public Client With Secret Ref",
+			"enabled": true,
+			"publicClient": true,
+			"standardFlowEnabled": true,
+			"redirectUris": ["http://localhost:8080/*"]
+		}`, clientName))
+		kcClient := &keycloakv1beta1.KeycloakClient{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clientName,
+				Namespace: testNamespace,
+			},
+			Spec: keycloakv1beta1.KeycloakClientSpec{
+				RealmRef:   &keycloakv1beta1.ResourceRef{Name: realmName},
+				Definition: &clientDef,
+				ClientSecretRef: &keycloakv1beta1.ClientSecretRefSpec{
+					Name: clientName + "-secret",
+				},
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, kcClient))
+		t.Cleanup(func() {
+			k8sClient.Delete(ctx, kcClient)
+		})
+
+		// Wait for client to be ready
+		err := wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+			updated := &keycloakv1beta1.KeycloakClient{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      kcClient.Name,
+				Namespace: kcClient.Namespace,
+			}, updated); err != nil {
+				return false, nil
+			}
+			return updated.Status.Ready, nil
+		})
+		require.NoError(t, err, "Public client with SecretRef did not become ready")
+
+		// Verify secret was created with client-id only
+		secret := &corev1.Secret{}
+		err = wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+			if err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      clientName + "-secret",
+				Namespace: testNamespace,
+			}, secret); err != nil {
+				return false, nil
+			}
+			return true, nil
+		})
+		require.NoError(t, err, "Secret was not created for public client with ClientSecretRef")
+		require.Contains(t, secret.Data, "client-id", "Secret should contain client-id")
+		require.Equal(t, clientName, string(secret.Data["client-id"]), "client-id value should match clientId")
+		require.NotContains(t, secret.Data, "client-secret", "Public client Secret must not contain client-secret key")
+		t.Logf("Public client Secret created with keys: %v", getSecretKeys(secret))
+	})
+
 	t.Run("BearerOnlyClient", func(t *testing.T) {
 		// Create bearer-only client (for backend services)
 		clientName := fmt.Sprintf("bearer-client-%d", time.Now().UnixNano())


### PR DESCRIPTION
## Problem

Public OAuth clients (`publicClient: true`) have no client_secret — Keycloak returns an empty string on `GET /clients/{id}/client-secret`. The current operator therefore writes no Kubernetes Secret at all for public clients, but consumers (mobile apps, frontends) still need to inject the `client-id` via `envFrom` / `secretKeyRef` to authenticate against Keycloak. Each consumer chart then has to special-case the public-vs-confidential distinction.

## Solution

When syncing a public client, still create / update the K8s Secret — but emit only the `client-id` key (no `client-secret`). This matches the behavior of the older `legacy.k8s.keycloak.org` operator and lets consumer charts treat public and confidential clients uniformly via `envFrom`.

- `syncClientSecret` no longer early-returns when Keycloak yields an empty `client_secret`; it materializes the Secret with only the `client-id` key.
- `ensureClientSecret` returns `("", false, nil)` for public clients when the configured secret key is missing (instead of erroring), so re-reconciliation does not loop on `SecretError`.
- Adds a pure `isPublicClient` helper with unit tests.

## API change

None at the spec level. `ClientSecretRefSpec` already exposes `ClientIdKey` (defaulting to `client-id`); this PR makes the materialization path honor it for public clients.

## Tests

- Unit: `TestIsPublicClient` covers public / explicit-confidential / field-absent / empty / garbage / nil-spec cases.
- E2E: `PublicClientWithSecretRef` creates a public client, asserts the K8s Secret has only `client-id` (no `client-secret`).

## Diff summary

6 files, +147 / -7:

- `api/v1beta1/keycloakclient_types.go`
- `charts/keycloak-operator/files/crds/keycloak.hostzero.com_keycloakclients.yaml`
- `config/crd/bases/keycloak.hostzero.com_keycloakclients.yaml`
- `internal/controller/keycloakclient_controller.go`
- `internal/controller/keycloakclient_controller_test.go` — new
- `test/e2e/client_test.go`
