### PR TITLE
Enforce auth flow execution order and detect drift, fixes #76

### DIFF
--- a/docs/src/crds/keycloakauthenticationflow.md
+++ b/docs/src/crds/keycloakauthenticationflow.md
@@ -232,7 +232,7 @@ kubectl get kcaf       # KeycloakAuthenticationFlow
 
 ## Behavior on update
 
-When the spec changes the controller reconciles the live flow in place rather than deleting and recreating it. The top-level flow ID stays stable across updates, which is what allows a flow to be referenced as a sub-flow execution by another flow or as a realm binding override (`browserFlow`, `registrationFlow`, etc.) and still be edited — Keycloak refuses to delete a flow that is currently in use, so an out-of-place rebuild would fail.
+Every reconcile (spec change or periodic resync) reads the live execution tree from Keycloak and converges it with the spec, so external drift — admin UI edits, `kcadm` reorders, realm re-imports — is reverted on the next pass. The top-level flow ID stays stable across updates so flows referenced as a sub-flow execution or as a realm binding (`browserFlow`, `registrationFlow`, etc.) keep working.
 
 The reconciler walks the desired tree against the live tree and applies the minimum set of API calls:
 
@@ -246,7 +246,7 @@ The reconciler walks the desired tree against the live tree and applies the mini
   - if `requirement` differs, it is patched via `PUT /authentication/flows/{alias}/executions`.
   - leaf `authenticatorConfig` is converged: created when the spec adds it, deleted when the spec drops it, and updated in place via `PUT /authentication/config/{id}` when the key/value contents change.
   - sub-flow nodes recurse — children of matched sub-flows are reconciled the same way.
-- **Reorder:** at the end of each level, the controller raises priorities until the live order matches the desired order.
+- **Reorder:** at the end of each level, the controller assigns explicit `priority` values to every child via `PUT /authentication/flows/{alias}/executions` so the live order matches the spec deterministically. See [Known limitations](#known-limitations) for the Keycloak version requirement.
 
 A one-line summary of what changed (`added=N updated=M removed=K reorderedParents=R`) is logged for each update.
 
@@ -258,6 +258,12 @@ Two changes cannot be applied in place and are reported as failures with a clear
 
 - **Top-level `providerId` change** (e.g. `basic-flow` → `client-flow`): Keycloak does not support swapping the provider type of an existing flow. The status is set to `ProviderChangeUnsupported` and the message tells you to pick a new alias.
 - **Renaming the top-level `alias`**: the controller treats this as "old flow + new flow"; the old flow has to be removed by deleting its `KeycloakAuthenticationFlow` resource.
+
+## Known limitations
+
+### Execution ordering requires Keycloak 25+
+
+Order enforcement relies on the `priority` field added to `PUT /authentication/flows/{alias}/executions` in [keycloak/keycloak#27751](https://github.com/keycloak/keycloak/pull/27751). On Keycloak 24 and older the field is silently dropped, so the operator cannot enforce or repair execution order on those versions. Initial order still matches the spec there because pre-25 Keycloak assigned sequential priorities on add. Other drift (adds, removes, requirement changes, config changes) is detected and repaired on every Keycloak version.
 
 ## Notes
 

--- a/internal/controller/keycloakauthenticationflow_controller.go
+++ b/internal/controller/keycloakauthenticationflow_controller.go
@@ -201,12 +201,6 @@ func (r *KeycloakAuthenticationFlowReconciler) Reconcile(ctx context.Context, re
 	}
 
 	if existingFlowID != "" {
-		if flow.Status.ObservedGeneration == 0 || flow.Status.ObservedGeneration >= flow.Generation {
-			log.Info("flow already exists", "alias", flow.Spec.Alias, "id", existingFlowID)
-			return r.updateStatus(ctx, flow, true, "Ready", "Authentication flow synchronized", existingFlowID, realmName)
-		}
-
-		log.Info("spec changed, updating flow in place", "alias", flow.Spec.Alias)
 		stats, err := r.updateExistingFlow(ctx, kc, realmName, flow, existingFlowID, executions)
 		if err != nil {
 			RecordError(controllerName, "keycloak_api_error")
@@ -215,14 +209,18 @@ func (r *KeycloakAuthenticationFlowReconciler) Reconcile(ctx context.Context, re
 			}
 			return r.updateStatus(ctx, flow, false, "UpdateFailed", fmt.Sprintf("Failed to update flow: %v", err), existingFlowID, realmName)
 		}
-		log.Info("authentication flow updated in place",
-			"alias", flow.Spec.Alias,
-			"id", existingFlowID,
-			"added", stats.added,
-			"updated", stats.updated,
-			"removed", stats.removed,
-			"reorderedParents", stats.reorderedParents,
-		)
+		if stats.touched() {
+			log.Info("authentication flow updated in place",
+				"alias", flow.Spec.Alias,
+				"id", existingFlowID,
+				"added", stats.added,
+				"updated", stats.updated,
+				"removed", stats.removed,
+				"reorderedParents", stats.reorderedParents,
+			)
+		} else {
+			log.V(1).Info("flow already in sync, skipping update", "alias", flow.Spec.Alias, "id", existingFlowID)
+		}
 		return r.updateStatus(ctx, flow, true, "Ready", "Authentication flow synchronized", existingFlowID, realmName)
 	}
 
@@ -292,7 +290,7 @@ func (r *KeycloakAuthenticationFlowReconciler) addExecutions(ctx context.Context
 		}
 	}
 	if len(executions) > 1 {
-		if err := r.reorderChildren(ctx, kc, realmName, parentAlias, executions); err != nil {
+		if _, err := r.reorderChildren(ctx, kc, realmName, parentAlias, executions); err != nil {
 			return fmt.Errorf("reordering executions in flow %q: %w", parentAlias, err)
 		}
 	}
@@ -372,47 +370,88 @@ func buildSubFlowDef(alias, description, providerId string) map[string]interface
 	return def
 }
 
-// reorderChildren bubble-sorts the direct children of parentAlias into the
-// order described by desired, using Keycloak's raise-priority endpoint (the
-// only tool the API offers for reordering).
-func (r *KeycloakAuthenticationFlowReconciler) reorderChildren(ctx context.Context, kc *keycloak.Client, realmName, parentAlias string, desired []flowExecution) error {
-	ids := make([]execIdentifier, 0, len(desired))
-	for _, e := range desired {
-		if e.SubFlow != nil {
-			ids = append(ids, execIdentifier{name: e.SubFlow.Alias, isFlow: true})
-		} else {
-			ids = append(ids, execIdentifier{name: e.Authenticator, isFlow: false})
-		}
+// Gap left between priorities so future inserts don't need to renumber.
+const reorderPriorityStep = 10
+
+// reorderChildren PUTs an explicit priority on each child of parentAlias so
+// the live order matches desired. Requires Keycloak 25+: older versions drop
+// the priority field, and the raise-/lower-priority swap endpoints don't
+// help on KC 25/26 either because new executions all share priority 0
+// (keycloak/keycloak#35765). Returns true when at least one PUT was issued.
+func (r *KeycloakAuthenticationFlowReconciler) reorderChildren(ctx context.Context, kc *keycloak.Client, realmName, parentAlias string, desired []flowExecution) (bool, error) {
+	execs, err := kc.GetFlowExecutions(ctx, realmName, parentAlias)
+	if err != nil {
+		return false, err
 	}
+	topLevel := filterTopLevelExecutions(execs)
 
-	for targetIdx := 0; targetIdx < len(ids); targetIdx++ {
-		execs, err := kc.GetFlowExecutions(ctx, realmName, parentAlias)
-		if err != nil {
-			return err
-		}
-		topLevel := filterTopLevelExecutions(execs)
-
-		currentIdx := -1
-		for i, e := range topLevel {
-			if matchesIdentifier(e, ids[targetIdx]) {
-				currentIdx = i
+	matchIdx := make([]int, len(desired))
+	used := make([]bool, len(topLevel))
+	for i, d := range desired {
+		id := desiredIdentifier(d)
+		matchIdx[i] = -1
+		for j := range topLevel {
+			if used[j] {
+				continue
+			}
+			if matchesIdentifier(topLevel[j], id) {
+				matchIdx[i] = j
+				used[j] = true
 				break
 			}
 		}
-		if currentIdx < 0 || currentIdx == targetIdx {
+		if matchIdx[i] < 0 {
+			return false, fmt.Errorf("execution %q not found in flow %q after add (cannot reorder)", id.name, parentAlias)
+		}
+	}
+
+	// Position equality alone is not enough: with all priorities at 0,
+	// Keycloak's sort order for ties is non-deterministic, so we'd skip
+	// the PUTs and never lock the order in. Require a positive priority.
+	if liveMatchesDesiredOrder(topLevel, matchIdx) {
+		return false, nil
+	}
+
+	for i, j := range matchIdx {
+		match := topLevel[j]
+		if match.ID == nil {
 			continue
 		}
-
-		for i := 0; i < currentIdx-targetIdx; i++ {
-			if topLevel[currentIdx].ID == nil {
-				break
-			}
-			if err := kc.RaiseExecutionPriority(ctx, realmName, *topLevel[currentIdx].ID); err != nil {
-				return fmt.Errorf("raising priority of execution: %w", err)
-			}
+		priority := (i + 1) * reorderPriorityStep
+		upd := keycloak.AuthenticationExecutionInfo{
+			ID:       match.ID,
+			Priority: &priority,
+		}
+		if match.Requirement != nil {
+			upd.Requirement = match.Requirement
+		}
+		if match.AuthenticationFlow != nil {
+			upd.AuthenticationFlow = match.AuthenticationFlow
+		}
+		if err := kc.UpdateFlowExecution(ctx, realmName, parentAlias, upd); err != nil {
+			return true, fmt.Errorf("setting priority on execution %q in flow %q: %w", desired[i].Authenticator, parentAlias, err)
 		}
 	}
-	return nil
+	return true, nil
+}
+
+func liveMatchesDesiredOrder(topLevel []keycloak.AuthenticationExecutionInfo, matchIdx []int) bool {
+	for i, j := range matchIdx {
+		if i != j {
+			return false
+		}
+		if topLevel[j].Priority == nil || *topLevel[j].Priority <= 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func desiredIdentifier(e flowExecution) execIdentifier {
+	if e.SubFlow != nil {
+		return execIdentifier{name: e.SubFlow.Alias, isFlow: true}
+	}
+	return execIdentifier{name: e.Authenticator, isFlow: false}
 }
 
 // findExecution locates a direct child of flowAlias by its provider ID
@@ -524,6 +563,13 @@ type updateStats struct {
 	added, updated, removed, reorderedParents int
 }
 
+func (s *updateStats) touched() bool {
+	if s == nil {
+		return false
+	}
+	return s.added > 0 || s.updated > 0 || s.removed > 0 || s.reorderedParents > 0
+}
+
 // matchExecutions pairs each desired entry with at most one live entry of the
 // same identity (provider id for leaves, alias for sub-flows). Matching is
 // occurrence-based: the i-th desired entry with identity X matches the i-th
@@ -620,10 +666,13 @@ func (r *KeycloakAuthenticationFlowReconciler) reconcileChildren(
 	}
 
 	if len(desired) > 1 {
-		if err := r.reorderChildren(ctx, kc, realmName, parentAlias, desired); err != nil {
+		changed, err := r.reorderChildren(ctx, kc, realmName, parentAlias, desired)
+		if err != nil {
 			return fmt.Errorf("reordering executions in flow %q: %w", parentAlias, err)
 		}
-		stats.reorderedParents++
+		if changed {
+			stats.reorderedParents++
+		}
 	}
 	return nil
 }
@@ -752,6 +801,8 @@ func (r *KeycloakAuthenticationFlowReconciler) updateExistingFlow(
 			errProviderChangeUnsupported, *live.ProviderID, flow.Spec.ProviderId)
 	}
 
+	stats := &updateStats{}
+
 	liveDescription := ""
 	if live.Description != nil {
 		liveDescription = *live.Description
@@ -770,6 +821,7 @@ func (r *KeycloakAuthenticationFlowReconciler) updateExistingFlow(
 		if err := kc.UpdateAuthenticationFlow(ctx, realmName, existingFlowID, upd); err != nil {
 			return nil, fmt.Errorf("updating top-level fields of flow %q: %w", flow.Spec.Alias, err)
 		}
+		stats.updated++
 	}
 
 	liveTree, err := r.readLiveTree(ctx, kc, realmName, flow.Spec.Alias)
@@ -777,7 +829,6 @@ func (r *KeycloakAuthenticationFlowReconciler) updateExistingFlow(
 		return nil, fmt.Errorf("reading live execution tree for flow %q: %w", flow.Spec.Alias, err)
 	}
 
-	stats := &updateStats{}
 	if err := r.reconcileChildren(ctx, kc, realmName, flow.Spec.Alias, executions, liveTree, stats); err != nil {
 		return nil, err
 	}

--- a/internal/controller/keycloakauthenticationflow_helpers_test.go
+++ b/internal/controller/keycloakauthenticationflow_helpers_test.go
@@ -343,6 +343,30 @@ func TestMatchExecutions(t *testing.T) {
 	})
 }
 
+func TestDesiredIdentifier(t *testing.T) {
+	tests := []struct {
+		name string
+		exec flowExecution
+		want execIdentifier
+	}{
+		{
+			name: "authenticator returns provider id",
+			exec: flowExecution{Authenticator: "auth-cookie", Requirement: "ALTERNATIVE"},
+			want: execIdentifier{name: "auth-cookie", isFlow: false},
+		},
+		{
+			name: "sub-flow returns alias and isFlow=true",
+			exec: flowExecution{SubFlow: &flowDefinition{Alias: "forms", ProviderID: "basic-flow"}, Requirement: "ALTERNATIVE"},
+			want: execIdentifier{name: "forms", isFlow: true},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, desiredIdentifier(tt.exec))
+		})
+	}
+}
+
 func TestConfigMapsEqual(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/keycloak/client.go
+++ b/internal/keycloak/client.go
@@ -1416,19 +1416,22 @@ type AuthenticationFlowRepresentation struct {
 // by GET /authentication/flows/{flowAlias}/executions. This is a flat list with
 // level/index fields indicating the tree structure.
 type AuthenticationExecutionInfo struct {
-	ID                   *string  `json:"id,omitempty"`
-	Requirement          *string  `json:"requirement,omitempty"`
-	DisplayName          *string  `json:"displayName,omitempty"`
-	Alias                *string  `json:"alias,omitempty"`
-	Description          *string  `json:"description,omitempty"`
-	Configurable         *bool    `json:"configurable,omitempty"`
-	AuthenticationFlow   *bool    `json:"authenticationFlow,omitempty"`
-	ProviderID           *string  `json:"providerId,omitempty"`
-	AuthenticationConfig *string  `json:"authenticationConfig,omitempty"`
-	FlowID               *string  `json:"flowId,omitempty"`
-	Level                *int     `json:"level,omitempty"`
-	Index                *int     `json:"index,omitempty"`
-	RequirementChoices   []string `json:"requirementChoices,omitempty"`
+	ID                   *string `json:"id,omitempty"`
+	Requirement          *string `json:"requirement,omitempty"`
+	DisplayName          *string `json:"displayName,omitempty"`
+	Alias                *string `json:"alias,omitempty"`
+	Description          *string `json:"description,omitempty"`
+	Configurable         *bool   `json:"configurable,omitempty"`
+	AuthenticationFlow   *bool   `json:"authenticationFlow,omitempty"`
+	ProviderID           *string `json:"providerId,omitempty"`
+	AuthenticationConfig *string `json:"authenticationConfig,omitempty"`
+	FlowID               *string `json:"flowId,omitempty"`
+	Level                *int    `json:"level,omitempty"`
+	Index                *int    `json:"index,omitempty"`
+	// Priority is only honored on PUT since Keycloak 25
+	// (keycloak/keycloak#27751); older versions silently drop it.
+	Priority           *int     `json:"priority,omitempty"`
+	RequirementChoices []string `json:"requirementChoices,omitempty"`
 }
 
 // AuthenticatorConfigRepresentation represents an authenticator config

--- a/test/e2e/authenticationflow_test.go
+++ b/test/e2e/authenticationflow_test.go
@@ -541,6 +541,173 @@ func TestKeycloakAuthenticationFlowE2E(t *testing.T) {
 		t.Logf("Realm-bound flow %s updated in place without releasing the binding", flowAlias)
 	})
 
+	// Regression for keycloak/keycloak#35765 (new executions all default to
+	// priority 0 on KC 25/26, so order is non-deterministic without an
+	// explicit priority).
+	t.Run("FlowExecutionOrderMatchesSpec", func(t *testing.T) {
+		skipIfNoKeycloakAccess(t)
+		flowAlias := fmt.Sprintf("ordered-flow-%d", time.Now().UnixNano())
+		subFlowA := flowAlias + "-sub-a"
+		subFlowB := flowAlias + "-sub-b"
+		flow := &keycloakv1beta1.KeycloakAuthenticationFlow{
+			ObjectMeta: metav1.ObjectMeta{Name: flowAlias, Namespace: testNamespace},
+			Spec: keycloakv1beta1.KeycloakAuthenticationFlowSpec{
+				RealmRef:    &keycloakv1beta1.ResourceRef{Name: realmName},
+				Alias:       flowAlias,
+				Description: "Order regression for keycloak/keycloak#35765",
+				ProviderId:  "basic-flow",
+				Executions: rawExecutions(fmt.Sprintf(`[
+					{"authenticator":"direct-grant-validate-username","requirement":"REQUIRED"},
+					{
+						"subFlow":{
+							"alias":"%s",
+							"providerId":"basic-flow",
+							"executions":[
+								{"authenticator":"conditional-user-configured","requirement":"REQUIRED"}
+							]
+						},
+						"requirement":"CONDITIONAL"
+					},
+					{"authenticator":"direct-grant-validate-password","requirement":"REQUIRED"},
+					{
+						"subFlow":{
+							"alias":"%s",
+							"providerId":"basic-flow",
+							"executions":[
+								{"authenticator":"conditional-user-configured","requirement":"REQUIRED"},
+								{"authenticator":"direct-grant-validate-otp","requirement":"REQUIRED"}
+							]
+						},
+						"requirement":"CONDITIONAL"
+					},
+					{"authenticator":"user-session-limits","requirement":"REQUIRED"}
+				]`, subFlowA, subFlowB)),
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, flow))
+		t.Cleanup(func() { k8sClient.Delete(ctx, flow) })
+
+		waitForFlowReady(t, flow.Name)
+
+		want := []string{
+			"direct-grant-validate-username",
+			subFlowA,
+			"direct-grant-validate-password",
+			subFlowB,
+			"user-session-limits",
+		}
+
+		kc := getInternalKeycloakClient(t)
+		execs, err := kc.GetFlowExecutions(ctx, realmName, flowAlias)
+		require.NoError(t, err)
+
+		var got []string
+		for i := range execs {
+			e := execs[i]
+			if e.Level == nil || *e.Level != 0 {
+				continue
+			}
+			switch {
+			case e.AuthenticationFlow != nil && *e.AuthenticationFlow && e.DisplayName != nil:
+				got = append(got, *e.DisplayName)
+			case e.ProviderID != nil:
+				got = append(got, *e.ProviderID)
+			}
+		}
+		require.Equal(t, want, got, "top-level executions must appear in the order declared in the spec")
+
+		subBExecs, err := kc.GetFlowExecutions(ctx, realmName, subFlowB)
+		require.NoError(t, err)
+		var subBGot []string
+		for _, e := range subBExecs {
+			if e.Level != nil && *e.Level == 0 && e.ProviderID != nil {
+				subBGot = append(subBGot, *e.ProviderID)
+			}
+		}
+		require.Equal(t, []string{"conditional-user-configured", "direct-grant-validate-otp"}, subBGot,
+			"sub-flow executions must also appear in the order declared in the spec")
+		t.Logf("Flow %s executions are in spec order", flowAlias)
+	})
+
+	t.Run("FlowExecutionOrderDriftIsRepaired", func(t *testing.T) {
+		skipIfNoKeycloakAccess(t)
+		flowAlias := fmt.Sprintf("drift-order-flow-%d", time.Now().UnixNano())
+		flow := &keycloakv1beta1.KeycloakAuthenticationFlow{
+			ObjectMeta: metav1.ObjectMeta{Name: flowAlias, Namespace: testNamespace},
+			Spec: keycloakv1beta1.KeycloakAuthenticationFlowSpec{
+				RealmRef:    &keycloakv1beta1.ResourceRef{Name: realmName},
+				Alias:       flowAlias,
+				Description: "Order drift regression",
+				ProviderId:  "basic-flow",
+				Executions: rawExecutions(`[
+					{"authenticator":"direct-grant-validate-username","requirement":"REQUIRED"},
+					{"authenticator":"direct-grant-validate-password","requirement":"REQUIRED"},
+					{"authenticator":"direct-grant-validate-otp","requirement":"REQUIRED"}
+				]`),
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, flow))
+		t.Cleanup(func() { k8sClient.Delete(ctx, flow) })
+
+		waitForFlowReady(t, flow.Name)
+
+		kc := getInternalKeycloakClient(t)
+
+		// Drift Keycloak directly without touching the CR.
+		live, err := kc.GetFlowExecutions(ctx, realmName, flowAlias)
+		require.NoError(t, err)
+		var otpID string
+		for _, e := range live {
+			if e.Level != nil && *e.Level == 0 && e.ProviderID != nil && *e.ProviderID == "direct-grant-validate-otp" {
+				require.NotNil(t, e.ID)
+				otpID = *e.ID
+				break
+			}
+		}
+		require.NotEmpty(t, otpID, "OTP execution must exist in live flow")
+		require.NoError(t, kc.RaiseExecutionPriority(ctx, realmName, otpID))
+		require.NoError(t, kc.RaiseExecutionPriority(ctx, realmName, otpID))
+
+		drifted, err := kc.GetFlowExecutions(ctx, realmName, flowAlias)
+		require.NoError(t, err)
+		var driftedOrder []string
+		for _, e := range drifted {
+			if e.Level != nil && *e.Level == 0 && e.ProviderID != nil {
+				driftedOrder = append(driftedOrder, *e.ProviderID)
+			}
+		}
+		require.Equal(t, []string{
+			"direct-grant-validate-otp",
+			"direct-grant-validate-username",
+			"direct-grant-validate-password",
+		}, driftedOrder, "raise-priority must have actually moved the OTP to the top")
+
+		// Force a reconcile without bumping the spec.
+		fresh := &keycloakv1beta1.KeycloakAuthenticationFlow{}
+		require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: flow.Name, Namespace: flow.Namespace}, fresh))
+		bumpReconcile(t, fresh)
+
+		require.Eventually(t, func() bool {
+			repaired, err := kc.GetFlowExecutions(ctx, realmName, flowAlias)
+			if err != nil {
+				return false
+			}
+			var got []string
+			for _, e := range repaired {
+				if e.Level != nil && *e.Level == 0 && e.ProviderID != nil {
+					got = append(got, *e.ProviderID)
+				}
+			}
+			want := []string{
+				"direct-grant-validate-username",
+				"direct-grant-validate-password",
+				"direct-grant-validate-otp",
+			}
+			return len(got) == len(want) && got[0] == want[0] && got[1] == want[1] && got[2] == want[2]
+		}, 30*time.Second, 500*time.Millisecond, "controller did not repair execution order drift")
+		t.Logf("Flow %s execution order drift was detected and repaired", flowAlias)
+	})
+
 	t.Run("FlowCleanup", func(t *testing.T) {
 		flowAlias := fmt.Sprintf("cleanup-flow-%d", time.Now().UnixNano())
 		flow := &keycloakv1beta1.KeycloakAuthenticationFlow{


### PR DESCRIPTION
On Keycloak 25/26 newly added flow executions all default to priority 0 (keycloak/keycloak#35765), so the previous raise-priority bubble-sort silently no-oped and the live order depended on Keycloak's storage order. Set explicit, monotonically increasing priorities via PUT (supported since Keycloak 25, keycloak/keycloak#27751) so the live tree matches the spec deterministically.

Drop the observedGeneration short-circuit in Reconcile so every pass reads the live tree and converges it with the spec, matching the client / realm / user / IdP controllers. External drift (admin UI reorders, kcadm scripts, realm re-imports) is now repaired on the next reconcile. In-sync flows log "flow already in sync, skipping update" at V(1) with zero writes.

Added two e2e regressions: FlowExecutionOrderMatchesSpec (order on initial create with nested sub-flows) and FlowExecutionOrderDriftIsRepaired (out-of-band reorder is reverted without a spec change).