### PR TITLE
feat(controller): implement role reference resolution in KeycloakRole…

### DIFF
--- a/docs/src/crds/keycloakrolemapping.md
+++ b/docs/src/crds/keycloakrolemapping.md
@@ -125,21 +125,42 @@ spec:
 
 **Using `roleRef`:**
 1. The operator looks up the referenced `KeycloakRole` resource
-2. It retrieves the Keycloak role ID from the role's status
-3. This is the recommended approach for roles managed by the operator
+2. It reads `status.roleName` from that resource (which may differ from the CR name)
+3. If the referenced `KeycloakRole` has its own `spec.clientRef`, the mapping is automatically scoped to that client and the client's UUID is resolved from the `KeycloakClient`'s status
+4. The referenced role (and the client it points at, if any) must be Ready; otherwise the mapping requeues
+5. This is the recommended approach for roles managed by the operator
 
 **Using `role.name`:**
 1. The operator queries Keycloak for a role with the given name
 2. This is useful for built-in roles like `offline_access`
 
+### Cross-Namespace References
+
+`subject.userRef`, `subject.groupRef`, `roleRef`, and `role.clientRef` all accept an optional `namespace` field. When set, the operator resolves the reference in that namespace instead of the mapping's own namespace. The same applies to the `clientRef` on a referenced `KeycloakRole`, so the role, its client, and the subject may each live in different namespaces.
+
+```yaml
+spec:
+  subject:
+    userRef:
+      name: my-user
+      namespace: users
+  roleRef:
+    name: my-role
+    namespace: roles
+```
+
 ### Mapping Types
 
-| Subject | Role Type | Result |
-|---------|-----------|--------|
-| userRef | realm role (no clientRef) | User realm role mapping |
-| userRef | client role (role.clientRef set) | User client role mapping |
-| groupRef | realm role (no clientRef) | Group realm role mapping |
-| groupRef | client role (role.clientRef set) | Group client role mapping |
+| Subject | Role source | Result |
+|---------|-------------|--------|
+| userRef | inline `role` without `clientRef`/`clientId` | User realm role mapping |
+| userRef | inline `role` with `clientRef` or `clientId` | User client role mapping |
+| userRef | `roleRef` to a `KeycloakRole` without `clientRef` | User realm role mapping |
+| userRef | `roleRef` to a `KeycloakRole` with `clientRef` | User client role mapping |
+| groupRef | inline `role` without `clientRef`/`clientId` | Group realm role mapping |
+| groupRef | inline `role` with `clientRef` or `clientId` | Group client role mapping |
+| groupRef | `roleRef` to a `KeycloakRole` without `clientRef` | Group realm role mapping |
+| groupRef | `roleRef` to a `KeycloakRole` with `clientRef` | Group client role mapping |
 
 ### Cleanup
 

--- a/internal/controller/keycloakrolemapping_controller.go
+++ b/internal/controller/keycloakrolemapping_controller.go
@@ -260,8 +260,32 @@ func (r *KeycloakRoleMappingReconciler) resolveRole(ctx context.Context, mapping
 		return roleName, "realm", "", nil
 	}
 
-	// RoleRef - not implemented yet, would need a KeycloakRole CRD
-	return "", "", "", fmt.Errorf("roleRef not yet supported")
+	role, err := r.getRole(ctx, mapping)
+	if err != nil {
+		return "", "", "", err
+	}
+	if !role.Status.Ready || role.Status.RoleName == "" {
+		return "", "", "", fmt.Errorf("role %s is not ready", role.Name)
+	}
+
+	roleName := role.Status.RoleName
+
+	if role.Spec.ClientRef != nil {
+		namespace := role.Namespace
+		if role.Spec.ClientRef.Namespace != nil {
+			namespace = *role.Spec.ClientRef.Namespace
+		}
+		client := &keycloakv1beta1.KeycloakClient{}
+		if err := r.Get(ctx, types.NamespacedName{Name: role.Spec.ClientRef.Name, Namespace: namespace}, client); err != nil {
+			return roleName, "client", "", fmt.Errorf("failed to get client %s/%s: %w", namespace, role.Spec.ClientRef.Name, err)
+		}
+		if !client.Status.Ready || client.Status.ClientUUID == "" {
+			return roleName, "client", "", fmt.Errorf("client %s is not ready", client.Name)
+		}
+		return roleName, "client", client.Status.ClientUUID, nil
+	}
+
+	return roleName, "realm", "", nil
 }
 
 func (r *KeycloakRoleMappingReconciler) getUser(ctx context.Context, mapping *keycloakv1beta1.KeycloakRoleMapping) (*keycloakv1beta1.KeycloakUser, error) {
@@ -290,6 +314,20 @@ func (r *KeycloakRoleMappingReconciler) getGroup(ctx context.Context, mapping *k
 		return nil, fmt.Errorf("failed to get group %s/%s: %w", namespace, ref.Name, err)
 	}
 	return group, nil
+}
+
+func (r *KeycloakRoleMappingReconciler) getRole(ctx context.Context, mapping *keycloakv1beta1.KeycloakRoleMapping) (*keycloakv1beta1.KeycloakRole, error) {
+	ref := mapping.Spec.RoleRef
+	namespace := mapping.Namespace
+	if ref.Namespace != nil {
+		namespace = *ref.Namespace
+	}
+
+	role := &keycloakv1beta1.KeycloakRole{}
+	if err := r.Get(ctx, types.NamespacedName{Name: ref.Name, Namespace: namespace}, role); err != nil {
+		return nil, fmt.Errorf("failed to get role %s/%s: %w", namespace, ref.Name, err)
+	}
+	return role, nil
 }
 
 func (r *KeycloakRoleMappingReconciler) getClient(ctx context.Context, mapping *keycloakv1beta1.KeycloakRoleMapping, ref *keycloakv1beta1.ResourceRef) (*keycloakv1beta1.KeycloakClient, error) {

--- a/internal/controller/keycloakrolemapping_controller_test.go
+++ b/internal/controller/keycloakrolemapping_controller_test.go
@@ -1,0 +1,649 @@
+package controller
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	keycloakv1beta1 "github.com/Hostzero-GmbH/keycloak-operator/api/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := keycloakv1beta1.AddToScheme(s); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	return s
+}
+
+func TestResolveRole_InlineRole_Realm(t *testing.T) {
+	mapping := &keycloakv1beta1.KeycloakRoleMapping{
+		ObjectMeta: metav1.ObjectMeta{Name: "mapping", Namespace: "default"},
+		Spec: keycloakv1beta1.KeycloakRoleMappingSpec{
+			Role: &keycloakv1beta1.RoleDefinition{Name: "admin"},
+		},
+	}
+
+	r := &KeycloakRoleMappingReconciler{
+		Client: fake.NewClientBuilder().WithScheme(newScheme(t)).Build(),
+	}
+
+	roleName, roleType, clientUUID, err := r.resolveRole(context.Background(), mapping, nil, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if roleName != "admin" || roleType != "realm" || clientUUID != "" {
+		t.Errorf("got (%q, %q, %q), want (admin, realm, \"\")", roleName, roleType, clientUUID)
+	}
+}
+
+func TestResolveRole_InlineRole_ClientRef_Ready(t *testing.T) {
+	kcClient := &keycloakv1beta1.KeycloakClient{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-client", Namespace: "default"},
+		Status:     keycloakv1beta1.KeycloakClientStatus{Ready: true, ClientUUID: "uuid-999"},
+	}
+	mapping := &keycloakv1beta1.KeycloakRoleMapping{
+		ObjectMeta: metav1.ObjectMeta{Name: "mapping", Namespace: "default"},
+		Spec: keycloakv1beta1.KeycloakRoleMappingSpec{
+			Role: &keycloakv1beta1.RoleDefinition{
+				Name:      "viewer",
+				ClientRef: &keycloakv1beta1.ResourceRef{Name: "my-client"},
+			},
+		},
+	}
+
+	r := &KeycloakRoleMappingReconciler{
+		Client: fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(kcClient).Build(),
+	}
+
+	roleName, roleType, clientUUID, err := r.resolveRole(context.Background(), mapping, nil, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if roleName != "viewer" || roleType != "client" || clientUUID != "uuid-999" {
+		t.Errorf("got (%q, %q, %q), want (viewer, client, uuid-999)", roleName, roleType, clientUUID)
+	}
+}
+
+func TestResolveRole_InlineRole_ClientRef_NotReady(t *testing.T) {
+	kcClient := &keycloakv1beta1.KeycloakClient{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-client", Namespace: "default"},
+		Status:     keycloakv1beta1.KeycloakClientStatus{Ready: false},
+	}
+	mapping := &keycloakv1beta1.KeycloakRoleMapping{
+		ObjectMeta: metav1.ObjectMeta{Name: "mapping", Namespace: "default"},
+		Spec: keycloakv1beta1.KeycloakRoleMappingSpec{
+			Role: &keycloakv1beta1.RoleDefinition{
+				Name:      "viewer",
+				ClientRef: &keycloakv1beta1.ResourceRef{Name: "my-client"},
+			},
+		},
+	}
+
+	r := &KeycloakRoleMappingReconciler{
+		Client: fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(kcClient).Build(),
+	}
+
+	_, _, _, err := r.resolveRole(context.Background(), mapping, nil, "")
+	if err == nil {
+		t.Fatal("expected error for unready client, got nil")
+	}
+}
+
+func TestResolveRole_InlineRole_ClientRef_NotFound(t *testing.T) {
+	mapping := &keycloakv1beta1.KeycloakRoleMapping{
+		ObjectMeta: metav1.ObjectMeta{Name: "mapping", Namespace: "default"},
+		Spec: keycloakv1beta1.KeycloakRoleMappingSpec{
+			Role: &keycloakv1beta1.RoleDefinition{
+				Name:      "viewer",
+				ClientRef: &keycloakv1beta1.ResourceRef{Name: "missing-client"},
+			},
+		},
+	}
+
+	r := &KeycloakRoleMappingReconciler{
+		Client: fake.NewClientBuilder().WithScheme(newScheme(t)).Build(),
+	}
+
+	_, _, _, err := r.resolveRole(context.Background(), mapping, nil, "")
+	if err == nil {
+		t.Fatal("expected error for missing client, got nil")
+	}
+}
+
+func TestResolveRole_RoleRef_RealmRole(t *testing.T) {
+	role := &keycloakv1beta1.KeycloakRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-role", Namespace: "default"},
+		Status:     keycloakv1beta1.KeycloakRoleStatus{Ready: true, RoleName: "my-role"},
+	}
+	mapping := &keycloakv1beta1.KeycloakRoleMapping{
+		ObjectMeta: metav1.ObjectMeta{Name: "mapping", Namespace: "default"},
+		Spec: keycloakv1beta1.KeycloakRoleMappingSpec{
+			RoleRef: &keycloakv1beta1.ResourceRef{Name: "my-role"},
+		},
+	}
+
+	r := &KeycloakRoleMappingReconciler{
+		Client: fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(role).Build(),
+	}
+
+	roleName, roleType, clientUUID, err := r.resolveRole(context.Background(), mapping, nil, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if roleName != "my-role" || roleType != "realm" || clientUUID != "" {
+		t.Errorf("got (%q, %q, %q), want (my-role, realm, \"\")", roleName, roleType, clientUUID)
+	}
+}
+
+func TestResolveRole_RoleRef_ClientRole(t *testing.T) {
+	role := &keycloakv1beta1.KeycloakRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "viewer", Namespace: "default"},
+		Spec:       keycloakv1beta1.KeycloakRoleSpec{ClientRef: &keycloakv1beta1.ResourceRef{Name: "my-client"}},
+		Status:     keycloakv1beta1.KeycloakRoleStatus{Ready: true, RoleName: "viewer"},
+	}
+	kcClient := &keycloakv1beta1.KeycloakClient{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-client", Namespace: "default"},
+		Status:     keycloakv1beta1.KeycloakClientStatus{Ready: true, ClientUUID: "abc-123"},
+	}
+	mapping := &keycloakv1beta1.KeycloakRoleMapping{
+		ObjectMeta: metav1.ObjectMeta{Name: "mapping", Namespace: "default"},
+		Spec: keycloakv1beta1.KeycloakRoleMappingSpec{
+			RoleRef: &keycloakv1beta1.ResourceRef{Name: "viewer"},
+		},
+	}
+
+	r := &KeycloakRoleMappingReconciler{
+		Client: fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(role, kcClient).Build(),
+	}
+
+	roleName, roleType, clientUUID, err := r.resolveRole(context.Background(), mapping, nil, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if roleName != "viewer" || roleType != "client" || clientUUID != "abc-123" {
+		t.Errorf("got (%q, %q, %q), want (viewer, client, abc-123)", roleName, roleType, clientUUID)
+	}
+}
+
+func TestResolveRole_RoleRef_CrossNamespace(t *testing.T) {
+	role := &keycloakv1beta1.KeycloakRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "shared-role", Namespace: "shared"},
+		Status:     keycloakv1beta1.KeycloakRoleStatus{Ready: true, RoleName: "shared-role"},
+	}
+	mapping := &keycloakv1beta1.KeycloakRoleMapping{
+		ObjectMeta: metav1.ObjectMeta{Name: "mapping", Namespace: "default"},
+		Spec: keycloakv1beta1.KeycloakRoleMappingSpec{
+			RoleRef: &keycloakv1beta1.ResourceRef{Name: "shared-role", Namespace: ptr("shared")},
+		},
+	}
+
+	r := &KeycloakRoleMappingReconciler{
+		Client: fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(role).Build(),
+	}
+
+	roleName, roleType, clientUUID, err := r.resolveRole(context.Background(), mapping, nil, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if roleName != "shared-role" || roleType != "realm" || clientUUID != "" {
+		t.Errorf("got (%q, %q, %q), want (shared-role, realm, \"\")", roleName, roleType, clientUUID)
+	}
+}
+
+func TestResolveRole_RoleRef_NotReady(t *testing.T) {
+	role := &keycloakv1beta1.KeycloakRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-role", Namespace: "default"},
+		Status:     keycloakv1beta1.KeycloakRoleStatus{Ready: false},
+	}
+	mapping := &keycloakv1beta1.KeycloakRoleMapping{
+		ObjectMeta: metav1.ObjectMeta{Name: "mapping", Namespace: "default"},
+		Spec: keycloakv1beta1.KeycloakRoleMappingSpec{
+			RoleRef: &keycloakv1beta1.ResourceRef{Name: "my-role"},
+		},
+	}
+
+	r := &KeycloakRoleMappingReconciler{
+		Client: fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(role).Build(),
+	}
+
+	_, _, _, err := r.resolveRole(context.Background(), mapping, nil, "")
+	if err == nil {
+		t.Fatal("expected error for unready role, got nil")
+	}
+}
+
+func TestResolveRole_RoleRef_NotFound(t *testing.T) {
+	mapping := &keycloakv1beta1.KeycloakRoleMapping{
+		ObjectMeta: metav1.ObjectMeta{Name: "mapping", Namespace: "default"},
+		Spec: keycloakv1beta1.KeycloakRoleMappingSpec{
+			RoleRef: &keycloakv1beta1.ResourceRef{Name: "missing-role"},
+		},
+	}
+
+	r := &KeycloakRoleMappingReconciler{
+		Client: fake.NewClientBuilder().WithScheme(newScheme(t)).Build(),
+	}
+
+	_, _, _, err := r.resolveRole(context.Background(), mapping, nil, "")
+	if err == nil {
+		t.Fatal("expected error for missing role, got nil")
+	}
+}
+
+func TestResolveRole_RoleRef_ClientNotReady(t *testing.T) {
+	// The KeycloakRole is ready but the client it references is not.
+	role := &keycloakv1beta1.KeycloakRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "editor", Namespace: "default"},
+		Spec:       keycloakv1beta1.KeycloakRoleSpec{ClientRef: &keycloakv1beta1.ResourceRef{Name: "my-client"}},
+		Status:     keycloakv1beta1.KeycloakRoleStatus{Ready: true, RoleName: "editor"},
+	}
+	kcClient := &keycloakv1beta1.KeycloakClient{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-client", Namespace: "default"},
+		Status:     keycloakv1beta1.KeycloakClientStatus{Ready: false},
+	}
+	mapping := &keycloakv1beta1.KeycloakRoleMapping{
+		ObjectMeta: metav1.ObjectMeta{Name: "mapping", Namespace: "default"},
+		Spec: keycloakv1beta1.KeycloakRoleMappingSpec{
+			RoleRef: &keycloakv1beta1.ResourceRef{Name: "editor"},
+		},
+	}
+
+	r := &KeycloakRoleMappingReconciler{
+		Client: fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(role, kcClient).Build(),
+	}
+
+	_, _, _, err := r.resolveRole(context.Background(), mapping, nil, "")
+	if err == nil {
+		t.Fatal("expected error when referenced client is not ready, got nil")
+	}
+}
+
+func TestResolveRole_RoleRef_EmptyRoleName(t *testing.T) {
+	// Ready=true but RoleName="" is a distinct error path from Ready=false.
+	role := &keycloakv1beta1.KeycloakRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-role", Namespace: "default"},
+		Status:     keycloakv1beta1.KeycloakRoleStatus{Ready: true, RoleName: ""},
+	}
+	mapping := &keycloakv1beta1.KeycloakRoleMapping{
+		ObjectMeta: metav1.ObjectMeta{Name: "mapping", Namespace: "default"},
+		Spec: keycloakv1beta1.KeycloakRoleMappingSpec{
+			RoleRef: &keycloakv1beta1.ResourceRef{Name: "my-role"},
+		},
+	}
+
+	r := &KeycloakRoleMappingReconciler{
+		Client: fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(role).Build(),
+	}
+
+	_, _, _, err := r.resolveRole(context.Background(), mapping, nil, "")
+	if err == nil {
+		t.Fatal("expected error for role with empty RoleName, got nil")
+	}
+}
+
+func TestResolveRole_RoleRef_ClientRole_CrossNamespace(t *testing.T) {
+	// The KeycloakRole's clientRef points to a client in a different namespace.
+	role := &keycloakv1beta1.KeycloakRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "viewer", Namespace: "default"},
+		Spec:       keycloakv1beta1.KeycloakRoleSpec{ClientRef: &keycloakv1beta1.ResourceRef{Name: "shared-client", Namespace: ptr("shared")}},
+		Status:     keycloakv1beta1.KeycloakRoleStatus{Ready: true, RoleName: "viewer"},
+	}
+	kcClient := &keycloakv1beta1.KeycloakClient{
+		ObjectMeta: metav1.ObjectMeta{Name: "shared-client", Namespace: "shared"},
+		Status:     keycloakv1beta1.KeycloakClientStatus{Ready: true, ClientUUID: "cross-uuid"},
+	}
+	mapping := &keycloakv1beta1.KeycloakRoleMapping{
+		ObjectMeta: metav1.ObjectMeta{Name: "mapping", Namespace: "default"},
+		Spec: keycloakv1beta1.KeycloakRoleMappingSpec{
+			RoleRef: &keycloakv1beta1.ResourceRef{Name: "viewer"},
+		},
+	}
+
+	r := &KeycloakRoleMappingReconciler{
+		Client: fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(role, kcClient).Build(),
+	}
+
+	roleName, roleType, clientUUID, err := r.resolveRole(context.Background(), mapping, nil, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if roleName != "viewer" || roleType != "client" || clientUUID != "cross-uuid" {
+		t.Errorf("got (%q, %q, %q), want (viewer, client, cross-uuid)", roleName, roleType, clientUUID)
+	}
+}
+
+func TestResolveSubject_UserRef_NotFound(t *testing.T) {
+	mapping := &keycloakv1beta1.KeycloakRoleMapping{
+		ObjectMeta: metav1.ObjectMeta{Name: "mapping", Namespace: "default"},
+		Spec: keycloakv1beta1.KeycloakRoleMappingSpec{
+			Subject: keycloakv1beta1.RoleMappingSubject{
+				UserRef: &keycloakv1beta1.ResourceRef{Name: "alice"},
+			},
+		},
+	}
+
+	r := &KeycloakRoleMappingReconciler{
+		Client: fake.NewClientBuilder().WithScheme(newScheme(t)).Build(),
+	}
+
+	_, _, _, _, err := r.resolveSubject(context.Background(), mapping)
+	if err == nil {
+		t.Fatal("expected error for missing user, got nil")
+	}
+}
+
+func TestResolveSubject_UserRef_NotReady(t *testing.T) {
+	user := &keycloakv1beta1.KeycloakUser{
+		ObjectMeta: metav1.ObjectMeta{Name: "alice", Namespace: "default"},
+		Status:     keycloakv1beta1.KeycloakUserStatus{Ready: false},
+	}
+	mapping := &keycloakv1beta1.KeycloakRoleMapping{
+		ObjectMeta: metav1.ObjectMeta{Name: "mapping", Namespace: "default"},
+		Spec: keycloakv1beta1.KeycloakRoleMappingSpec{
+			Subject: keycloakv1beta1.RoleMappingSubject{
+				UserRef: &keycloakv1beta1.ResourceRef{Name: "alice"},
+			},
+		},
+	}
+
+	r := &KeycloakRoleMappingReconciler{
+		Client: fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(user).Build(),
+	}
+
+	subjectType, _, _, _, err := r.resolveSubject(context.Background(), mapping)
+	if err == nil {
+		t.Fatal("expected error for unready user, got nil")
+	}
+	if subjectType != "user" {
+		t.Errorf("subjectType = %q, want \"user\"", subjectType)
+	}
+}
+
+func TestResolveSubject_UserRef_CrossNamespace(t *testing.T) {
+	// The mapping lives in "default" but references a user in "shared".
+	// The not-ready error proves the lookup reached the correct namespace.
+	user := &keycloakv1beta1.KeycloakUser{
+		ObjectMeta: metav1.ObjectMeta{Name: "alice", Namespace: "shared"},
+		Status:     keycloakv1beta1.KeycloakUserStatus{Ready: false},
+	}
+	mapping := &keycloakv1beta1.KeycloakRoleMapping{
+		ObjectMeta: metav1.ObjectMeta{Name: "mapping", Namespace: "default"},
+		Spec: keycloakv1beta1.KeycloakRoleMappingSpec{
+			Subject: keycloakv1beta1.RoleMappingSubject{
+				UserRef: &keycloakv1beta1.ResourceRef{Name: "alice", Namespace: ptr("shared")},
+			},
+		},
+	}
+
+	r := &KeycloakRoleMappingReconciler{
+		Client: fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(user).Build(),
+	}
+
+	_, _, _, _, err := r.resolveSubject(context.Background(), mapping)
+	if err == nil {
+		t.Fatal("expected not-ready error, got nil")
+	}
+	if !strings.Contains(err.Error(), "not ready") {
+		t.Errorf("error %q should report not-ready", err.Error())
+	}
+}
+
+func TestResolveSubject_GroupRef_NotFound(t *testing.T) {
+	mapping := &keycloakv1beta1.KeycloakRoleMapping{
+		ObjectMeta: metav1.ObjectMeta{Name: "mapping", Namespace: "default"},
+		Spec: keycloakv1beta1.KeycloakRoleMappingSpec{
+			Subject: keycloakv1beta1.RoleMappingSubject{
+				GroupRef: &keycloakv1beta1.ResourceRef{Name: "devs"},
+			},
+		},
+	}
+
+	r := &KeycloakRoleMappingReconciler{
+		Client: fake.NewClientBuilder().WithScheme(newScheme(t)).Build(),
+	}
+
+	_, _, _, _, err := r.resolveSubject(context.Background(), mapping)
+	if err == nil {
+		t.Fatal("expected error for missing group, got nil")
+	}
+}
+
+func TestResolveSubject_GroupRef_NotReady(t *testing.T) {
+	group := &keycloakv1beta1.KeycloakGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "devs", Namespace: "default"},
+		Status:     keycloakv1beta1.KeycloakGroupStatus{Ready: false},
+	}
+	mapping := &keycloakv1beta1.KeycloakRoleMapping{
+		ObjectMeta: metav1.ObjectMeta{Name: "mapping", Namespace: "default"},
+		Spec: keycloakv1beta1.KeycloakRoleMappingSpec{
+			Subject: keycloakv1beta1.RoleMappingSubject{
+				GroupRef: &keycloakv1beta1.ResourceRef{Name: "devs"},
+			},
+		},
+	}
+
+	r := &KeycloakRoleMappingReconciler{
+		Client: fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(group).Build(),
+	}
+
+	subjectType, _, _, _, err := r.resolveSubject(context.Background(), mapping)
+	if err == nil {
+		t.Fatal("expected error for unready group, got nil")
+	}
+	if subjectType != "group" {
+		t.Errorf("subjectType = %q, want \"group\"", subjectType)
+	}
+}
+
+func TestFindRoleMappingsForUser(t *testing.T) {
+	aliceMapping := &keycloakv1beta1.KeycloakRoleMapping{
+		ObjectMeta: metav1.ObjectMeta{Name: "alice-mapping", Namespace: "default"},
+		Spec: keycloakv1beta1.KeycloakRoleMappingSpec{
+			Subject: keycloakv1beta1.RoleMappingSubject{UserRef: &keycloakv1beta1.ResourceRef{Name: "alice"}},
+		},
+	}
+	bobMapping := &keycloakv1beta1.KeycloakRoleMapping{
+		ObjectMeta: metav1.ObjectMeta{Name: "bob-mapping", Namespace: "default"},
+		Spec: keycloakv1beta1.KeycloakRoleMappingSpec{
+			Subject: keycloakv1beta1.RoleMappingSubject{UserRef: &keycloakv1beta1.ResourceRef{Name: "bob"}},
+		},
+	}
+	alice := &keycloakv1beta1.KeycloakUser{ObjectMeta: metav1.ObjectMeta{Name: "alice", Namespace: "default"}}
+
+	r := &KeycloakRoleMappingReconciler{
+		Client: fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(aliceMapping, bobMapping).Build(),
+	}
+
+	reqs := r.findRoleMappingsForUser(context.Background(), alice)
+	if len(reqs) != 1 {
+		t.Fatalf("got %d requests, want 1", len(reqs))
+	}
+	want := reconcile.Request{NamespacedName: types.NamespacedName{Name: "alice-mapping", Namespace: "default"}}
+	if reqs[0] != want {
+		t.Errorf("got %v, want %v", reqs[0], want)
+	}
+}
+
+func TestFindRoleMappingsForUser_IgnoresGroupMappings(t *testing.T) {
+	// A group mapping with the same name as the user must not be returned on a user event.
+	groupMapping := &keycloakv1beta1.KeycloakRoleMapping{
+		ObjectMeta: metav1.ObjectMeta{Name: "alice-group-mapping", Namespace: "default"},
+		Spec: keycloakv1beta1.KeycloakRoleMappingSpec{
+			Subject: keycloakv1beta1.RoleMappingSubject{GroupRef: &keycloakv1beta1.ResourceRef{Name: "alice"}},
+		},
+	}
+	alice := &keycloakv1beta1.KeycloakUser{ObjectMeta: metav1.ObjectMeta{Name: "alice", Namespace: "default"}}
+
+	r := &KeycloakRoleMappingReconciler{
+		Client: fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(groupMapping).Build(),
+	}
+
+	if reqs := r.findRoleMappingsForUser(context.Background(), alice); len(reqs) != 0 {
+		t.Errorf("got %d requests, want 0", len(reqs))
+	}
+}
+
+func TestFindRoleMappingsForGroup(t *testing.T) {
+	devsMapping := &keycloakv1beta1.KeycloakRoleMapping{
+		ObjectMeta: metav1.ObjectMeta{Name: "devs-mapping", Namespace: "default"},
+		Spec: keycloakv1beta1.KeycloakRoleMappingSpec{
+			Subject: keycloakv1beta1.RoleMappingSubject{GroupRef: &keycloakv1beta1.ResourceRef{Name: "devs"}},
+		},
+	}
+	opsMapping := &keycloakv1beta1.KeycloakRoleMapping{
+		ObjectMeta: metav1.ObjectMeta{Name: "ops-mapping", Namespace: "default"},
+		Spec: keycloakv1beta1.KeycloakRoleMappingSpec{
+			Subject: keycloakv1beta1.RoleMappingSubject{GroupRef: &keycloakv1beta1.ResourceRef{Name: "ops"}},
+		},
+	}
+	devs := &keycloakv1beta1.KeycloakGroup{ObjectMeta: metav1.ObjectMeta{Name: "devs", Namespace: "default"}}
+
+	r := &KeycloakRoleMappingReconciler{
+		Client: fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(devsMapping, opsMapping).Build(),
+	}
+
+	reqs := r.findRoleMappingsForGroup(context.Background(), devs)
+	if len(reqs) != 1 {
+		t.Fatalf("got %d requests, want 1", len(reqs))
+	}
+	want := reconcile.Request{NamespacedName: types.NamespacedName{Name: "devs-mapping", Namespace: "default"}}
+	if reqs[0] != want {
+		t.Errorf("got %v, want %v", reqs[0], want)
+	}
+}
+
+func TestFindRoleMappingsForGroup_IgnoresUserMappings(t *testing.T) {
+	// A user mapping with the same name as the group must not be returned on a group event.
+	userMapping := &keycloakv1beta1.KeycloakRoleMapping{
+		ObjectMeta: metav1.ObjectMeta{Name: "devs-user-mapping", Namespace: "default"},
+		Spec: keycloakv1beta1.KeycloakRoleMappingSpec{
+			Subject: keycloakv1beta1.RoleMappingSubject{UserRef: &keycloakv1beta1.ResourceRef{Name: "devs"}},
+		},
+	}
+	devs := &keycloakv1beta1.KeycloakGroup{ObjectMeta: metav1.ObjectMeta{Name: "devs", Namespace: "default"}}
+
+	r := &KeycloakRoleMappingReconciler{
+		Client: fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(userMapping).Build(),
+	}
+
+	if reqs := r.findRoleMappingsForGroup(context.Background(), devs); len(reqs) != 0 {
+		t.Errorf("got %d requests, want 0", len(reqs))
+	}
+}
+
+func TestReconcile_InvalidSpec_NoSubject(t *testing.T) {
+	mapping := &keycloakv1beta1.KeycloakRoleMapping{
+		ObjectMeta: metav1.ObjectMeta{Name: "mapping", Namespace: "default"},
+		Spec: keycloakv1beta1.KeycloakRoleMappingSpec{
+			// Subject is empty — neither UserRef nor GroupRef set
+			Role: &keycloakv1beta1.RoleDefinition{Name: "admin"},
+		},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(newScheme(t)).
+		WithStatusSubresource(&keycloakv1beta1.KeycloakRoleMapping{}).
+		WithObjects(mapping).
+		Build()
+	r := &KeycloakRoleMappingReconciler{Client: cl}
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "mapping", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := &keycloakv1beta1.KeycloakRoleMapping{}
+	if err := cl.Get(context.Background(), types.NamespacedName{Name: "mapping", Namespace: "default"}, got); err != nil {
+		t.Fatalf("failed to get mapping after reconcile: %v", err)
+	}
+	if got.Status.Ready {
+		t.Error("Status.Ready = true, want false")
+	}
+	if got.Status.Status != "InvalidSpec" {
+		t.Errorf("Status.Status = %q, want \"InvalidSpec\"", got.Status.Status)
+	}
+}
+
+func TestReconcile_InvalidSpec_NoRole(t *testing.T) {
+	mapping := &keycloakv1beta1.KeycloakRoleMapping{
+		ObjectMeta: metav1.ObjectMeta{Name: "mapping", Namespace: "default"},
+		Spec: keycloakv1beta1.KeycloakRoleMappingSpec{
+			Subject: keycloakv1beta1.RoleMappingSubject{
+				UserRef: &keycloakv1beta1.ResourceRef{Name: "alice"},
+			},
+			// Neither Role nor RoleRef set
+		},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(newScheme(t)).
+		WithStatusSubresource(&keycloakv1beta1.KeycloakRoleMapping{}).
+		WithObjects(mapping).
+		Build()
+	r := &KeycloakRoleMappingReconciler{Client: cl}
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "mapping", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := &keycloakv1beta1.KeycloakRoleMapping{}
+	if err := cl.Get(context.Background(), types.NamespacedName{Name: "mapping", Namespace: "default"}, got); err != nil {
+		t.Fatalf("failed to get mapping after reconcile: %v", err)
+	}
+	if got.Status.Ready {
+		t.Error("Status.Ready = true, want false")
+	}
+	if got.Status.Status != "InvalidSpec" {
+		t.Errorf("Status.Status = %q, want \"InvalidSpec\"", got.Status.Status)
+	}
+}
+
+func TestReconcile_AddsFinalizerOnFirstReconcile(t *testing.T) {
+	mapping := &keycloakv1beta1.KeycloakRoleMapping{
+		ObjectMeta: metav1.ObjectMeta{Name: "mapping", Namespace: "default"},
+		Spec: keycloakv1beta1.KeycloakRoleMappingSpec{
+			Subject: keycloakv1beta1.RoleMappingSubject{
+				UserRef: &keycloakv1beta1.ResourceRef{Name: "alice"},
+			},
+			RoleRef: &keycloakv1beta1.ResourceRef{Name: "my-role"},
+		},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(newScheme(t)).
+		WithStatusSubresource(&keycloakv1beta1.KeycloakRoleMapping{}).
+		WithObjects(mapping).
+		Build()
+	r := &KeycloakRoleMappingReconciler{Client: cl}
+
+	result, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "mapping", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Requeue {
+		t.Error("expected Requeue=true after adding finalizer, got false")
+	}
+
+	got := &keycloakv1beta1.KeycloakRoleMapping{}
+	if err := cl.Get(context.Background(), types.NamespacedName{Name: "mapping", Namespace: "default"}, got); err != nil {
+		t.Fatalf("failed to get mapping after reconcile: %v", err)
+	}
+	if !controllerutil.ContainsFinalizer(got, FinalizerName) {
+		t.Errorf("finalizer %q was not added", FinalizerName)
+	}
+}

--- a/test/e2e/rolemapping_test.go
+++ b/test/e2e/rolemapping_test.go
@@ -405,6 +405,198 @@ func TestKeycloakRoleMappingCleanup(t *testing.T) {
 	})
 }
 
+// TestKeycloakRoleMappingRoleRefE2E covers the roleRef code path, where the
+// mapping points at an operator-managed KeycloakRole instead of an inline role
+// name. The client-role subtest also exercises the transitive lookup from the
+// referenced KeycloakRole to its own clientRef.
+func TestKeycloakRoleMappingRoleRefE2E(t *testing.T) {
+	skipIfNoCluster(t)
+
+	instanceName, instanceNS := getOrCreateInstance(t)
+	realmName := createTestRealm(t, instanceName, instanceNS, "rolemapping-roleref")
+
+	t.Run("RealmRoleViaRoleRef", func(t *testing.T) {
+		userName := fmt.Sprintf("roleref-user-%d", time.Now().UnixNano())
+		userDef := rawJSON(fmt.Sprintf(`{
+			"username": "%s",
+			"enabled": true
+		}`, userName))
+		kcUser := &keycloakv1beta1.KeycloakUser{
+			ObjectMeta: metav1.ObjectMeta{Name: userName, Namespace: testNamespace},
+			Spec: keycloakv1beta1.KeycloakUserSpec{
+				RealmRef:   &keycloakv1beta1.ResourceRef{Name: realmName},
+				Definition: &userDef,
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, kcUser))
+		t.Cleanup(func() { k8sClient.Delete(ctx, kcUser) })
+
+		err := wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+			updated := &keycloakv1beta1.KeycloakUser{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: kcUser.Name, Namespace: kcUser.Namespace}, updated); err != nil {
+				return false, nil
+			}
+			return updated.Status.Ready, nil
+		})
+		require.NoError(t, err, "KeycloakUser did not become ready")
+
+		roleName := fmt.Sprintf("roleref-realm-role-%d", time.Now().UnixNano())
+		role := &keycloakv1beta1.KeycloakRole{
+			ObjectMeta: metav1.ObjectMeta{Name: roleName, Namespace: testNamespace},
+			Spec: keycloakv1beta1.KeycloakRoleSpec{
+				RealmRef:   &keycloakv1beta1.ResourceRef{Name: realmName},
+				Definition: rawJSON(fmt.Sprintf(`{"name":"%s"}`, roleName)),
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, role))
+		t.Cleanup(func() { k8sClient.Delete(ctx, role) })
+
+		err = wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+			updated := &keycloakv1beta1.KeycloakRole{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: role.Name, Namespace: role.Namespace}, updated); err != nil {
+				return false, nil
+			}
+			return updated.Status.Ready && updated.Status.RoleName != "", nil
+		})
+		require.NoError(t, err, "KeycloakRole did not become ready")
+
+		mappingName := fmt.Sprintf("roleref-realm-mapping-%d", time.Now().UnixNano())
+		mapping := &keycloakv1beta1.KeycloakRoleMapping{
+			ObjectMeta: metav1.ObjectMeta{Name: mappingName, Namespace: testNamespace},
+			Spec: keycloakv1beta1.KeycloakRoleMappingSpec{
+				Subject: keycloakv1beta1.RoleMappingSubject{
+					UserRef: &keycloakv1beta1.ResourceRef{Name: userName},
+				},
+				RoleRef: &keycloakv1beta1.ResourceRef{Name: roleName},
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, mapping))
+		t.Cleanup(func() { k8sClient.Delete(ctx, mapping) })
+
+		err = wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+			updated := &keycloakv1beta1.KeycloakRoleMapping{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: mapping.Name, Namespace: mapping.Namespace}, updated); err != nil {
+				return false, nil
+			}
+			return updated.Status.Ready, nil
+		})
+		require.NoError(t, err, "KeycloakRoleMapping via roleRef did not become ready")
+
+		updated := &keycloakv1beta1.KeycloakRoleMapping{}
+		require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: mapping.Name, Namespace: mapping.Namespace}, updated))
+		require.Equal(t, "Ready", updated.Status.Status)
+		require.Equal(t, "user", updated.Status.SubjectType)
+		require.Equal(t, "realm", updated.Status.RoleType)
+		require.Equal(t, roleName, updated.Status.RoleName)
+		requireReadyCondition(t, updated.Status.Conditions, metav1.ConditionTrue)
+		t.Logf("Realm role via roleRef mapping %s is ready", mappingName)
+	})
+
+	t.Run("ClientRoleViaRoleRef", func(t *testing.T) {
+		// Exercises the new transitive lookup: KeycloakRole has its own clientRef,
+		// so the mapping must follow it and resolve the client UUID.
+		clientName := fmt.Sprintf("roleref-client-%d", time.Now().UnixNano())
+		clientDef := rawJSON(fmt.Sprintf(`{
+			"clientId": "%s",
+			"enabled": true
+		}`, clientName))
+		kcClient := &keycloakv1beta1.KeycloakClient{
+			ObjectMeta: metav1.ObjectMeta{Name: clientName, Namespace: testNamespace},
+			Spec: keycloakv1beta1.KeycloakClientSpec{
+				RealmRef:   &keycloakv1beta1.ResourceRef{Name: realmName},
+				Definition: &clientDef,
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, kcClient))
+		t.Cleanup(func() { k8sClient.Delete(ctx, kcClient) })
+
+		err := wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+			updated := &keycloakv1beta1.KeycloakClient{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: kcClient.Name, Namespace: kcClient.Namespace}, updated); err != nil {
+				return false, nil
+			}
+			return updated.Status.Ready && updated.Status.ClientUUID != "", nil
+		})
+		require.NoError(t, err, "KeycloakClient did not become ready")
+
+		roleName := fmt.Sprintf("roleref-client-role-%d", time.Now().UnixNano())
+		role := &keycloakv1beta1.KeycloakRole{
+			ObjectMeta: metav1.ObjectMeta{Name: roleName, Namespace: testNamespace},
+			Spec: keycloakv1beta1.KeycloakRoleSpec{
+				RealmRef:   &keycloakv1beta1.ResourceRef{Name: realmName},
+				ClientRef:  &keycloakv1beta1.ResourceRef{Name: clientName},
+				Definition: rawJSON(fmt.Sprintf(`{"name":"%s"}`, roleName)),
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, role))
+		t.Cleanup(func() { k8sClient.Delete(ctx, role) })
+
+		err = wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+			updated := &keycloakv1beta1.KeycloakRole{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: role.Name, Namespace: role.Namespace}, updated); err != nil {
+				return false, nil
+			}
+			return updated.Status.Ready && updated.Status.RoleName != "", nil
+		})
+		require.NoError(t, err, "KeycloakRole (client-scoped) did not become ready")
+
+		userName := fmt.Sprintf("roleref-client-user-%d", time.Now().UnixNano())
+		userDef := rawJSON(fmt.Sprintf(`{
+			"username": "%s",
+			"enabled": true
+		}`, userName))
+		kcUser := &keycloakv1beta1.KeycloakUser{
+			ObjectMeta: metav1.ObjectMeta{Name: userName, Namespace: testNamespace},
+			Spec: keycloakv1beta1.KeycloakUserSpec{
+				RealmRef:   &keycloakv1beta1.ResourceRef{Name: realmName},
+				Definition: &userDef,
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, kcUser))
+		t.Cleanup(func() { k8sClient.Delete(ctx, kcUser) })
+
+		err = wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+			updated := &keycloakv1beta1.KeycloakUser{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: kcUser.Name, Namespace: kcUser.Namespace}, updated); err != nil {
+				return false, nil
+			}
+			return updated.Status.Ready, nil
+		})
+		require.NoError(t, err, "KeycloakUser did not become ready")
+
+		mappingName := fmt.Sprintf("roleref-client-mapping-%d", time.Now().UnixNano())
+		mapping := &keycloakv1beta1.KeycloakRoleMapping{
+			ObjectMeta: metav1.ObjectMeta{Name: mappingName, Namespace: testNamespace},
+			Spec: keycloakv1beta1.KeycloakRoleMappingSpec{
+				Subject: keycloakv1beta1.RoleMappingSubject{
+					UserRef: &keycloakv1beta1.ResourceRef{Name: userName},
+				},
+				RoleRef: &keycloakv1beta1.ResourceRef{Name: roleName},
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, mapping))
+		t.Cleanup(func() { k8sClient.Delete(ctx, mapping) })
+
+		err = wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+			updated := &keycloakv1beta1.KeycloakRoleMapping{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: mapping.Name, Namespace: mapping.Namespace}, updated); err != nil {
+				return false, nil
+			}
+			return updated.Status.Ready, nil
+		})
+		require.NoError(t, err, "Client role via roleRef mapping did not become ready")
+
+		updated := &keycloakv1beta1.KeycloakRoleMapping{}
+		require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: mapping.Name, Namespace: mapping.Namespace}, updated))
+		require.Equal(t, "Ready", updated.Status.Status)
+		require.Equal(t, "user", updated.Status.SubjectType)
+		require.Equal(t, "client", updated.Status.RoleType)
+		require.Equal(t, roleName, updated.Status.RoleName)
+		requireReadyCondition(t, updated.Status.Conditions, metav1.ConditionTrue)
+		t.Logf("Client role via roleRef mapping %s is ready", mappingName)
+	})
+}
+
 func TestKeycloakClientRoleMapping(t *testing.T) {
 	skipIfNoCluster(t)
 


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Implements `RoleRef` resolution in the `KeycloakRoleMapping` controller. Previously `resolveRole` returned an error when a `roleRef` was specified. 

It now looks up the referenced `KeycloakRole` resource, resolves the role name from its status, and - if the role has a `clientRef` - looks up the corresponding `KeycloakClient` to obtain the client UUID. Cross-namespace references are supported for both the role and its client.

Also adds a full test suite covering all pure-k8s paths through `resolveRole`, `resolveSubject`, the watch trigger helpers, and `Reconcile` spec validation.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

<!-- Link any related issues here using "Fixes #123" or "Relates to #123" -->

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`make test`)
- [x] I have updated the documentation if needed
- [x] I have updated the CHANGELOG.md if this is a user-facing change

## Testing

<!-- Describe how you tested your changes -->

Prior to this PR there was a test file for the Role Mapping Controller. But i introduced one which should prevent regressions in the future.

The tests i added:
- `resolveRole` with inline `Role`: realm role, client role via `clientRef` (ready / not ready / not found)
- `resolveRole` with `RoleRef`: realm role, client role, cross-namespace role ref, cross-namespace `clientRef` inside the role, not found, not ready, `Ready=true` with empty `RoleName`, referenced client not ready
- `resolveSubject`: user ref and group ref - not found, not ready, cross-namespace
- `findRoleMappingsForUser` / `findRoleMappingsForGroup`: returns only relevant mappings, ignores the other subject type
- `Reconcile`: invalid spec (no subject, no role), finalizer added on first reconcile

## Additional Notes

<!-- Any additional information that reviewers should know -->
