### PR TITLE
fix: prevent continious update organization loop

### DIFF
--- a/docs/src/crds/keycloakorganization.md
+++ b/docs/src/crds/keycloakorganization.md
@@ -163,6 +163,10 @@ kubectl get kcorg
 - **Keycloak 26.0.0+**: Organizations are a feature introduced in Keycloak 26. The operator will report an error if you try to create an organization on an older Keycloak version.
 - **Organizations must be enabled**: The organization feature must be enabled in the realm settings.
 
+## Reconciliation
+
+Reconciliation is idempotent. On each periodic resync the operator fetches the current organization from Keycloak and compares it against the spec; the update PUT is skipped when they already match, so an unchanged organization does not generate redundant writes or log noise. `domains[].verified` is set by Keycloak on read and is ignored in the comparison, so leaving it unset (or out of sync with the server) does not trigger a perpetual update loop.
+
 ## Notes
 
 - Organizations are immutable by ID - once created, the `id` field cannot be changed

--- a/internal/controller/keycloak_config.go
+++ b/internal/controller/keycloak_config.go
@@ -720,6 +720,42 @@ func realmDefinitionsMatch(desired, current json.RawMessage) bool {
 	return definitionsMatch(desiredJSON, currentJSON)
 }
 
+// organizationDefinitionsMatch reports whether desired matches current,
+// ignoring domains[].verified which Keycloak sets on read.
+func organizationDefinitionsMatch(desired, current json.RawMessage) bool {
+	var desiredMap, currentMap map[string]interface{}
+	if err := json.Unmarshal(desired, &desiredMap); err != nil {
+		return false
+	}
+	if err := json.Unmarshal(current, &currentMap); err != nil {
+		return false
+	}
+
+	stripDomainVerified := func(m map[string]interface{}) {
+		domains, ok := m["domains"].([]interface{})
+		if !ok {
+			return
+		}
+		for _, d := range domains {
+			if dm, ok := d.(map[string]interface{}); ok {
+				delete(dm, "verified")
+			}
+		}
+	}
+	stripDomainVerified(desiredMap)
+	stripDomainVerified(currentMap)
+
+	desiredJSON, err := json.Marshal(desiredMap)
+	if err != nil {
+		return false
+	}
+	currentJSON, err := json.Marshal(currentMap)
+	if err != nil {
+		return false
+	}
+	return definitionsMatch(desiredJSON, currentJSON)
+}
+
 // roleCompositesSpec mirrors the "composites" field of a Keycloak
 // RoleRepresentation: realm roles by name and client roles keyed by clientId.
 type roleCompositesSpec struct {

--- a/internal/controller/keycloak_config_test.go
+++ b/internal/controller/keycloak_config_test.go
@@ -894,3 +894,36 @@ func TestRealmDefinitionsMatch_NonSmtpFieldDiff(t *testing.T) {
 		t.Error("expected no match: displayName differs")
 	}
 }
+
+func TestOrganizationDefinitionsMatch_DomainsVerifiedIgnored(t *testing.T) {
+	// Keycloak echoes domains[].verified on read. The CR cannot set it,
+	// so the diff must treat it as equal.
+	desired := json.RawMessage(`{"name":"acme","domains":[{"name":"acme.com"}]}`)
+	current := json.RawMessage(`{"id":"x","name":"acme","alias":"acme","enabled":true,"domains":[{"name":"acme.com","verified":true}]}`)
+
+	if !organizationDefinitionsMatch(desired, current) {
+		t.Error("expected match: server-set domains[].verified and current-only fields must not cause drift")
+	}
+}
+
+func TestOrganizationDefinitionsMatch_FieldDiff(t *testing.T) {
+	// A real field change must still surface as drift.
+	desired := json.RawMessage(`{"name":"acme","description":"new","domains":[{"name":"acme.com"}]}`)
+	current := json.RawMessage(`{"id":"x","name":"acme","description":"old","domains":[{"name":"acme.com","verified":false}]}`)
+
+	if organizationDefinitionsMatch(desired, current) {
+		t.Error("expected no match: description differs")
+	}
+}
+
+func TestOrganizationDefinitionsMatch_RedirectUrlDrift(t *testing.T) {
+	// redirectUrl exists on Keycloak 26's OrganizationRepresentation but is not
+	// modelled by the operator's struct. The raw-bytes diff must still detect
+	// drift when current omits a value the user set in spec.
+	desired := json.RawMessage(`{"name":"acme","redirectUrl":"https://app/cb","domains":[{"name":"acme.com"}]}`)
+	current := json.RawMessage(`{"id":"x","name":"acme","domains":[{"name":"acme.com","verified":false}]}`)
+
+	if organizationDefinitionsMatch(desired, current) {
+		t.Error("expected no match: desired redirectUrl missing from current")
+	}
+}

--- a/internal/controller/keycloakorganization_controller.go
+++ b/internal/controller/keycloakorganization_controller.go
@@ -140,16 +140,28 @@ func (r *KeycloakOrganizationReconciler) Reconcile(ctx context.Context, req ctrl
 		}
 		log.Info("organization created successfully", "name", orgDef.Name, "id", orgID)
 	} else {
-		// Organization exists, update it
+		// Skip the PUT when the server already matches the spec.
 		orgID = existingOrg.ID
 		orgDef.ID = orgID
 
-		log.Info("updating organization", "name", orgDef.Name, "realm", realmName)
-		if err := kc.UpdateOrganization(ctx, realmName, orgDef); err != nil {
-			RecordError(controllerName, "keycloak_api_error")
-			return r.updateStatus(ctx, org, false, "UpdateFailed", fmt.Sprintf("Failed to update organization: %v", err), orgID)
+		currentRaw, fetchErr := kc.GetOrganizationRaw(ctx, realmName, orgID)
+		needsUpdate := true
+		if fetchErr != nil {
+			log.Error(fetchErr, "failed to fetch current organization state, falling through to update")
+		} else if currentRaw != nil {
+			needsUpdate = !organizationDefinitionsMatch(org.Spec.Definition.Raw, currentRaw)
 		}
-		log.Info("organization updated successfully", "name", orgDef.Name)
+
+		if needsUpdate {
+			log.Info("updating organization", "name", orgDef.Name, "realm", realmName)
+			if err := kc.UpdateOrganization(ctx, realmName, orgDef); err != nil {
+				RecordError(controllerName, "keycloak_api_error")
+				return r.updateStatus(ctx, org, false, "UpdateFailed", fmt.Sprintf("Failed to update organization: %v", err), orgID)
+			}
+			log.Info("organization updated successfully", "name", orgDef.Name)
+		} else {
+			log.V(1).Info("organization already in sync, skipping update", "name", orgDef.Name)
+		}
 	}
 
 	// Update status

--- a/test/e2e/drift_skip_test.go
+++ b/test/e2e/drift_skip_test.go
@@ -232,6 +232,70 @@ func TestDriftSkip(t *testing.T) {
 		require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: realm.Name, Namespace: realm.Namespace}, final))
 		require.True(t, final.Status.Ready, "realm should remain Ready after skipped reconcile")
 	})
+
+	t.Run("KeycloakOrganization_DomainsVerifiedNoLoop", func(t *testing.T) {
+		// Organizations require Keycloak 26+; skip on older instances.
+		instance := &keycloakv1beta1.KeycloakInstance{}
+		require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: instanceName, Namespace: testNamespace}, instance))
+		if instance.Status.Version == "" || instance.Status.Version[0:2] < "26" {
+			t.Skip("Organizations require Keycloak 26.0.0 or later")
+		}
+
+		realmName := createTestRealmWithOrganizations(t, instanceName, "drift-org")
+
+		orgName := fmt.Sprintf("drift-org-%d", time.Now().UnixNano())
+		// The spec omits domains[].verified. Keycloak sets it on read, which is
+		// the exact case organizationDefinitionsMatch strips so a naive
+		// byte-compare doesn't fire drift and PUT every reconcile.
+		orgDef := rawJSON(fmt.Sprintf(`{
+			"name": "%s",
+			"alias": "%s",
+			"enabled": true,
+			"domains": [{"name": "%s.example.com"}]
+		}`, orgName, orgName, orgName))
+
+		org := &keycloakv1beta1.KeycloakOrganization{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      orgName,
+				Namespace: testNamespace,
+			},
+			Spec: keycloakv1beta1.KeycloakOrganizationSpec{
+				RealmRef:   &keycloakv1beta1.ResourceRef{Name: realmName},
+				Definition: orgDef,
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, org))
+		t.Cleanup(func() { k8sClient.Delete(ctx, org) })
+
+		waitForOrganizationReady(t, org.Name, org.Namespace)
+
+		// Confirm Keycloak echoes domains[].verified on read — that's what
+		// drives the stripping branch in organizationDefinitionsMatch. If
+		// Keycloak stops doing this, fail fast rather than silently.
+		ready := &keycloakv1beta1.KeycloakOrganization{}
+		require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: org.Name, Namespace: org.Namespace}, ready))
+		kc := getInternalKeycloakClient(t)
+		raw, err := kc.GetOrganizationRaw(ctx, realmName, ready.Status.OrganizationID)
+		require.NoError(t, err)
+		var orgMap map[string]interface{}
+		require.NoError(t, json.Unmarshal(raw, &orgMap))
+		domains, _ := orgMap["domains"].([]interface{})
+		require.NotEmpty(t, domains, "domains missing on organization read-back")
+		firstDomain, _ := domains[0].(map[string]interface{})
+		require.NotNil(t, firstDomain, "domain entry not an object on read-back")
+		require.Contains(t, firstDomain, "verified",
+			"Keycloak no longer echoes domains[].verified; organizationDefinitionsMatch may need revisiting")
+
+		// Force a reconcile and assert the controller logs the skip line.
+		since := time.Now().UTC()
+		bumpReconcile(t, ready)
+
+		assertSkipLogged(t, since, "organization already in sync, skipping update", "name", orgName)
+
+		final := &keycloakv1beta1.KeycloakOrganization{}
+		require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: org.Name, Namespace: org.Namespace}, final))
+		require.True(t, final.Status.Ready, "organization should remain Ready after skipped reconcile")
+	})
 }
 
 // bumpReconcile patches an annotation onto the given object to force the
@@ -358,4 +422,17 @@ func waitForRealmReady(t *testing.T, name, namespace string) {
 		return updated.Status.Ready, nil
 	})
 	require.NoError(t, err, "KeycloakRealm %s/%s did not become ready", namespace, name)
+}
+
+// waitForOrganizationReady waits for a KeycloakOrganization to reach Ready status.
+func waitForOrganizationReady(t *testing.T, name, namespace string) {
+	t.Helper()
+	err := wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+		updated := &keycloakv1beta1.KeycloakOrganization{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, updated); err != nil {
+			return false, nil
+		}
+		return updated.Status.Ready, nil
+	})
+	require.NoError(t, err, "KeycloakOrganization %s/%s did not become ready", namespace, name)
 }


### PR DESCRIPTION
Operator was filling logs with messages of continiously updating Organization definitions within a realm.

The reconciler called UpdateOrganization on every loop, flooding the operator log and Keycloak with redundant PUTs.

Fetch current state via GetOrganizationRaw and compare with the spec using a new organizationDefinitionsMatch helper. The helper strips domains[].verified which Keycloak sets on read. Same pattern as the IdP and Realm controllers.

## Description

We are using `KeycloakOrganization` CRDs and we have noticed that operator was continiously updating the same organizations on every loop. We have used Claude Code to identify the route of the problem, which prepared this change.

Change was reviewed with two humans.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

<!-- Link any related issues here using "Fixes #123" or "Relates to #123" -->

## Checklist

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [X] My code follows the project's code style
- [X] I have added tests that prove my fix/feature works
- [X] All new and existing tests pass (`make test`)
- [x] I have updated the documentation if needed
- [x] I have updated the CHANGELOG.md if this is a user-facing change

## Testing

I ran it in our testing environments and change matches the expectations.

## Additional Notes

Thank you for you awesome work.