### PR TITLE
fix(crd): enforce mutually exclusive references

### DIFF
--- a/api/v1beta1/clusterkeycloakrealm_types.go
+++ b/api/v1beta1/clusterkeycloakrealm_types.go
@@ -6,6 +6,7 @@ import (
 )
 
 // ClusterKeycloakRealmSpec defines the desired state of ClusterKeycloakRealm
+// +kubebuilder:validation:XValidation:rule="has(self.instanceRef) != has(self.clusterInstanceRef)",message="exactly one of instanceRef or clusterInstanceRef must be set"
 type ClusterKeycloakRealmSpec struct {
 	// InstanceRef is a reference to a namespaced KeycloakInstance
 	// One of instanceRef or clusterInstanceRef must be specified

--- a/api/v1beta1/crd_validation_test.go
+++ b/api/v1beta1/crd_validation_test.go
@@ -1,0 +1,175 @@
+package v1beta1
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+func TestCRDReferenceChoiceValidation(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("add client-go scheme: %v", err)
+	}
+	if err := AddToScheme(scheme); err != nil {
+		t.Fatalf("add keycloak scheme: %v", err)
+	}
+
+	testEnv := &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
+	}
+	cfg, err := testEnv.Start()
+	if err != nil {
+		t.Fatalf("start envtest: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := testEnv.Stop(); err != nil {
+			t.Fatalf("stop envtest: %v", err)
+		}
+	})
+
+	k8sClient, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	const namespace = "crd-validation"
+	if err := k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}); err != nil {
+		t.Fatalf("create namespace: %v", err)
+	}
+
+	clientRef := &ResourceRef{Name: "client"}
+	clientID := "client-id"
+
+	tests := []struct {
+		name        string
+		object      client.Object
+		wantErrText string
+	}{
+		{
+			name: "KeycloakClient accepts exactly one realm reference",
+			object: &KeycloakClient{
+				ObjectMeta: metav1.ObjectMeta{Name: "client-valid", Namespace: namespace},
+				Spec:       KeycloakClientSpec{RealmRef: &ResourceRef{Name: "realm"}},
+			},
+		},
+		{
+			name: "KeycloakClient rejects missing realm reference",
+			object: &KeycloakClient{
+				ObjectMeta: metav1.ObjectMeta{Name: "client-missing", Namespace: namespace},
+				Spec:       KeycloakClientSpec{},
+			},
+			wantErrText: "exactly one of realmRef or clusterRealmRef must be set",
+		},
+		{
+			name: "KeycloakClient rejects both realm references",
+			object: &KeycloakClient{
+				ObjectMeta: metav1.ObjectMeta{Name: "client-both", Namespace: namespace},
+				Spec: KeycloakClientSpec{
+					RealmRef:        &ResourceRef{Name: "realm"},
+					ClusterRealmRef: &ClusterResourceRef{Name: "cluster-realm"},
+				},
+			},
+			wantErrText: "exactly one of realmRef or clusterRealmRef must be set",
+		},
+		{
+			name: "KeycloakUser accepts exactly one user target",
+			object: &KeycloakUser{
+				ObjectMeta: metav1.ObjectMeta{Name: "user-valid", Namespace: namespace},
+				Spec:       KeycloakUserSpec{ClientRef: clientRef},
+			},
+		},
+		{
+			name: "KeycloakUser rejects multiple user targets",
+			object: &KeycloakUser{
+				ObjectMeta: metav1.ObjectMeta{Name: "user-both", Namespace: namespace},
+				Spec: KeycloakUserSpec{
+					RealmRef:  &ResourceRef{Name: "realm"},
+					ClientRef: clientRef,
+				},
+			},
+			wantErrText: "exactly one of realmRef, clusterRealmRef, or clientRef must be set",
+		},
+		{
+			name: "KeycloakProtocolMapper rejects both parents",
+			object: &KeycloakProtocolMapper{
+				ObjectMeta: metav1.ObjectMeta{Name: "mapper-both", Namespace: namespace},
+				Spec: KeycloakProtocolMapperSpec{
+					ClientRef:      clientRef,
+					ClientScopeRef: &ResourceRef{Name: "scope"},
+					Definition:     runtime.RawExtension{Raw: []byte(`{"name":"mapper"}`)},
+				},
+			},
+			wantErrText: "exactly one of clientRef or clientScopeRef must be set",
+		},
+		{
+			name: "KeycloakRoleMapping rejects both role sources",
+			object: &KeycloakRoleMapping{
+				ObjectMeta: metav1.ObjectMeta{Name: "mapping-both-role", Namespace: namespace},
+				Spec: KeycloakRoleMappingSpec{
+					Subject: RoleMappingSubject{UserRef: &ResourceRef{Name: "user"}},
+					Role:    &RoleDefinition{Name: "role"},
+					RoleRef: &ResourceRef{Name: "role"},
+				},
+			},
+			wantErrText: "exactly one of role or roleRef must be set",
+		},
+		{
+			name: "KeycloakRoleMapping rejects both subject sources",
+			object: &KeycloakRoleMapping{
+				ObjectMeta: metav1.ObjectMeta{Name: "mapping-both-subject", Namespace: namespace},
+				Spec: KeycloakRoleMappingSpec{
+					Subject: RoleMappingSubject{
+						UserRef:  &ResourceRef{Name: "user"},
+						GroupRef: &ResourceRef{Name: "group"},
+					},
+					Role: &RoleDefinition{Name: "role"},
+				},
+			},
+			wantErrText: "exactly one of userRef or groupRef must be set",
+		},
+		{
+			name: "RoleDefinition rejects both client selectors",
+			object: &KeycloakRoleMapping{
+				ObjectMeta: metav1.ObjectMeta{Name: "mapping-both-client-role", Namespace: namespace},
+				Spec: KeycloakRoleMappingSpec{
+					Subject: RoleMappingSubject{UserRef: &ResourceRef{Name: "user"}},
+					Role: &RoleDefinition{
+						Name:      "role",
+						ClientRef: clientRef,
+						ClientID:  &clientID,
+					},
+				},
+			},
+			wantErrText: "at most one of clientRef or clientId may be set",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := k8sClient.Create(ctx, tt.object)
+			if tt.wantErrText == "" {
+				if err != nil {
+					t.Fatalf("create valid object: %v", err)
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatalf("expected create to fail with %q", tt.wantErrText)
+			}
+			if !strings.Contains(err.Error(), tt.wantErrText) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tt.wantErrText)
+			}
+		})
+	}
+}

--- a/api/v1beta1/keycloakauthenticationflow_types.go
+++ b/api/v1beta1/keycloakauthenticationflow_types.go
@@ -6,6 +6,7 @@ import (
 )
 
 // KeycloakAuthenticationFlowSpec defines the desired state of KeycloakAuthenticationFlow
+// +kubebuilder:validation:XValidation:rule="has(self.realmRef) != has(self.clusterRealmRef)",message="exactly one of realmRef or clusterRealmRef must be set"
 type KeycloakAuthenticationFlowSpec struct {
 	// RealmRef is a reference to a KeycloakRealm.
 	// One of realmRef or clusterRealmRef must be specified.

--- a/api/v1beta1/keycloakclient_types.go
+++ b/api/v1beta1/keycloakclient_types.go
@@ -6,6 +6,7 @@ import (
 )
 
 // KeycloakClientSpec defines the desired state of KeycloakClient
+// +kubebuilder:validation:XValidation:rule="has(self.realmRef) != has(self.clusterRealmRef)",message="exactly one of realmRef or clusterRealmRef must be set"
 type KeycloakClientSpec struct {
 	// RealmRef is a reference to a KeycloakRealm
 	// One of realmRef or clusterRealmRef must be specified

--- a/api/v1beta1/keycloakclientscope_types.go
+++ b/api/v1beta1/keycloakclientscope_types.go
@@ -6,6 +6,7 @@ import (
 )
 
 // KeycloakClientScopeSpec defines the desired state of KeycloakClientScope
+// +kubebuilder:validation:XValidation:rule="has(self.realmRef) != has(self.clusterRealmRef)",message="exactly one of realmRef or clusterRealmRef must be set"
 type KeycloakClientScopeSpec struct {
 	// RealmRef is a reference to a KeycloakRealm
 	// One of realmRef or clusterRealmRef must be specified

--- a/api/v1beta1/keycloakcomponent_types.go
+++ b/api/v1beta1/keycloakcomponent_types.go
@@ -6,6 +6,7 @@ import (
 )
 
 // KeycloakComponentSpec defines the desired state of KeycloakComponent
+// +kubebuilder:validation:XValidation:rule="has(self.realmRef) != has(self.clusterRealmRef)",message="exactly one of realmRef or clusterRealmRef must be set"
 type KeycloakComponentSpec struct {
 	// RealmRef is a reference to a KeycloakRealm
 	// One of realmRef or clusterRealmRef must be specified

--- a/api/v1beta1/keycloakgroup_types.go
+++ b/api/v1beta1/keycloakgroup_types.go
@@ -6,6 +6,7 @@ import (
 )
 
 // KeycloakGroupSpec defines the desired state of KeycloakGroup
+// +kubebuilder:validation:XValidation:rule="has(self.realmRef) != has(self.clusterRealmRef)",message="exactly one of realmRef or clusterRealmRef must be set"
 type KeycloakGroupSpec struct {
 	// RealmRef is a reference to a KeycloakRealm
 	// One of realmRef or clusterRealmRef must be specified

--- a/api/v1beta1/keycloakidentityprovider_types.go
+++ b/api/v1beta1/keycloakidentityprovider_types.go
@@ -6,6 +6,7 @@ import (
 )
 
 // KeycloakIdentityProviderSpec defines the desired state of KeycloakIdentityProvider
+// +kubebuilder:validation:XValidation:rule="has(self.realmRef) != has(self.clusterRealmRef)",message="exactly one of realmRef or clusterRealmRef must be set"
 type KeycloakIdentityProviderSpec struct {
 	// RealmRef is a reference to a KeycloakRealm
 	// One of realmRef or clusterRealmRef must be specified

--- a/api/v1beta1/keycloakorganization_types.go
+++ b/api/v1beta1/keycloakorganization_types.go
@@ -6,6 +6,7 @@ import (
 )
 
 // KeycloakOrganizationSpec defines the desired state of KeycloakOrganization
+// +kubebuilder:validation:XValidation:rule="has(self.realmRef) != has(self.clusterRealmRef)",message="exactly one of realmRef or clusterRealmRef must be set"
 type KeycloakOrganizationSpec struct {
 	// RealmRef is a reference to a KeycloakRealm
 	// One of realmRef or clusterRealmRef must be specified

--- a/api/v1beta1/keycloakprotocolmapper_types.go
+++ b/api/v1beta1/keycloakprotocolmapper_types.go
@@ -6,6 +6,7 @@ import (
 )
 
 // KeycloakProtocolMapperSpec defines the desired state of KeycloakProtocolMapper
+// +kubebuilder:validation:XValidation:rule="has(self.clientRef) != has(self.clientScopeRef)",message="exactly one of clientRef or clientScopeRef must be set"
 type KeycloakProtocolMapperSpec struct {
 	// ClientRef is a reference to a KeycloakClient
 	// One of clientRef or clientScopeRef must be specified

--- a/api/v1beta1/keycloakrealm_types.go
+++ b/api/v1beta1/keycloakrealm_types.go
@@ -20,6 +20,7 @@ type ClusterResourceRef struct {
 }
 
 // KeycloakRealmSpec defines the desired state of KeycloakRealm
+// +kubebuilder:validation:XValidation:rule="has(self.instanceRef) != has(self.clusterInstanceRef)",message="exactly one of instanceRef or clusterInstanceRef must be set"
 type KeycloakRealmSpec struct {
 	// InstanceRef is a reference to a KeycloakInstance
 	// One of instanceRef or clusterInstanceRef must be specified

--- a/api/v1beta1/keycloakrequiredaction_types.go
+++ b/api/v1beta1/keycloakrequiredaction_types.go
@@ -6,6 +6,7 @@ import (
 )
 
 // KeycloakRequiredActionSpec defines the desired state of KeycloakRequiredAction
+// +kubebuilder:validation:XValidation:rule="has(self.realmRef) != has(self.clusterRealmRef)",message="exactly one of realmRef or clusterRealmRef must be set"
 type KeycloakRequiredActionSpec struct {
 	// RealmRef is a reference to a KeycloakRealm
 	// One of realmRef or clusterRealmRef must be specified

--- a/api/v1beta1/keycloakrole_types.go
+++ b/api/v1beta1/keycloakrole_types.go
@@ -6,6 +6,7 @@ import (
 )
 
 // KeycloakRoleSpec defines the desired state of KeycloakRole
+// +kubebuilder:validation:XValidation:rule="has(self.realmRef) != has(self.clusterRealmRef)",message="exactly one of realmRef or clusterRealmRef must be set"
 type KeycloakRoleSpec struct {
 	// RealmRef is a reference to a KeycloakRealm
 	// One of realmRef or clusterRealmRef must be specified

--- a/api/v1beta1/keycloakrolemapping_types.go
+++ b/api/v1beta1/keycloakrolemapping_types.go
@@ -5,6 +5,7 @@ import (
 )
 
 // KeycloakRoleMappingSpec defines the desired state of KeycloakRoleMapping
+// +kubebuilder:validation:XValidation:rule="has(self.role) != has(self.roleRef)",message="exactly one of role or roleRef must be set"
 type KeycloakRoleMappingSpec struct {
 	// Subject defines who the role is assigned to (user or group)
 	// +kubebuilder:validation:Required
@@ -22,6 +23,7 @@ type KeycloakRoleMappingSpec struct {
 }
 
 // RoleMappingSubject defines the target of the role mapping
+// +kubebuilder:validation:XValidation:rule="has(self.userRef) != has(self.groupRef)",message="exactly one of userRef or groupRef must be set"
 type RoleMappingSubject struct {
 	// UserRef references a KeycloakUser
 	// +optional
@@ -33,6 +35,7 @@ type RoleMappingSubject struct {
 }
 
 // RoleDefinition defines a role inline
+// +kubebuilder:validation:XValidation:rule="!(has(self.clientRef) && has(self.clientId))",message="at most one of clientRef or clientId may be set"
 type RoleDefinition struct {
 	// Name is the role name
 	// +kubebuilder:validation:Required

--- a/api/v1beta1/keycloakuser_types.go
+++ b/api/v1beta1/keycloakuser_types.go
@@ -6,6 +6,7 @@ import (
 )
 
 // KeycloakUserSpec defines the desired state of KeycloakUser
+// +kubebuilder:validation:XValidation:rule="(has(self.realmRef) ? 1 : 0) + (has(self.clusterRealmRef) ? 1 : 0) + (has(self.clientRef) ? 1 : 0) == 1",message="exactly one of realmRef, clusterRealmRef, or clientRef must be set"
 type KeycloakUserSpec struct {
 	// RealmRef is a reference to a KeycloakRealm
 	// One of realmRef, clusterRealmRef, or clientRef must be specified

--- a/charts/keycloak-operator/files/crds/keycloak.hostzero.com_clusterkeycloakrealms.yaml
+++ b/charts/keycloak-operator/files/crds/keycloak.hostzero.com_clusterkeycloakrealms.yaml
@@ -125,6 +125,9 @@ spec:
             required:
             - definition
             type: object
+            x-kubernetes-validations:
+            - message: exactly one of instanceRef or clusterInstanceRef must be set
+              rule: has(self.instanceRef) != has(self.clusterInstanceRef)
           status:
             description: ClusterKeycloakRealmStatus defines the observed state of
               ClusterKeycloakRealm

--- a/charts/keycloak-operator/files/crds/keycloak.hostzero.com_keycloakauthenticationflows.yaml
+++ b/charts/keycloak-operator/files/crds/keycloak.hostzero.com_keycloakauthenticationflows.yaml
@@ -126,6 +126,9 @@ spec:
             - alias
             - providerId
             type: object
+            x-kubernetes-validations:
+            - message: exactly one of realmRef or clusterRealmRef must be set
+              rule: has(self.realmRef) != has(self.clusterRealmRef)
           status:
             description: KeycloakAuthenticationFlowStatus defines the observed state
               of KeycloakAuthenticationFlow

--- a/charts/keycloak-operator/files/crds/keycloak.hostzero.com_keycloakclients.yaml
+++ b/charts/keycloak-operator/files/crds/keycloak.hostzero.com_keycloakclients.yaml
@@ -118,6 +118,9 @@ spec:
                 - name
                 type: object
             type: object
+            x-kubernetes-validations:
+            - message: exactly one of realmRef or clusterRealmRef must be set
+              rule: has(self.realmRef) != has(self.clusterRealmRef)
           status:
             description: KeycloakClientStatus defines the observed state of KeycloakClient
             properties:

--- a/charts/keycloak-operator/files/crds/keycloak.hostzero.com_keycloakclientscopes.yaml
+++ b/charts/keycloak-operator/files/crds/keycloak.hostzero.com_keycloakclientscopes.yaml
@@ -85,6 +85,9 @@ spec:
             required:
             - definition
             type: object
+            x-kubernetes-validations:
+            - message: exactly one of realmRef or clusterRealmRef must be set
+              rule: has(self.realmRef) != has(self.clusterRealmRef)
           status:
             description: KeycloakClientScopeStatus defines the observed state of KeycloakClientScope
             properties:

--- a/charts/keycloak-operator/files/crds/keycloak.hostzero.com_keycloakcomponents.yaml
+++ b/charts/keycloak-operator/files/crds/keycloak.hostzero.com_keycloakcomponents.yaml
@@ -89,6 +89,9 @@ spec:
             required:
             - definition
             type: object
+            x-kubernetes-validations:
+            - message: exactly one of realmRef or clusterRealmRef must be set
+              rule: has(self.realmRef) != has(self.clusterRealmRef)
           status:
             description: KeycloakComponentStatus defines the observed state of KeycloakComponent
             properties:

--- a/charts/keycloak-operator/files/crds/keycloak.hostzero.com_keycloakgroups.yaml
+++ b/charts/keycloak-operator/files/crds/keycloak.hostzero.com_keycloakgroups.yaml
@@ -95,6 +95,9 @@ spec:
             required:
             - definition
             type: object
+            x-kubernetes-validations:
+            - message: exactly one of realmRef or clusterRealmRef must be set
+              rule: has(self.realmRef) != has(self.clusterRealmRef)
           status:
             description: KeycloakGroupStatus defines the observed state of KeycloakGroup
             properties:

--- a/charts/keycloak-operator/files/crds/keycloak.hostzero.com_keycloakidentityproviders.yaml
+++ b/charts/keycloak-operator/files/crds/keycloak.hostzero.com_keycloakidentityproviders.yaml
@@ -125,6 +125,9 @@ spec:
             required:
             - definition
             type: object
+            x-kubernetes-validations:
+            - message: exactly one of realmRef or clusterRealmRef must be set
+              rule: has(self.realmRef) != has(self.clusterRealmRef)
           status:
             description: KeycloakIdentityProviderStatus defines the observed state
               of KeycloakIdentityProvider

--- a/charts/keycloak-operator/files/crds/keycloak.hostzero.com_keycloakorganizations.yaml
+++ b/charts/keycloak-operator/files/crds/keycloak.hostzero.com_keycloakorganizations.yaml
@@ -87,6 +87,9 @@ spec:
             required:
             - definition
             type: object
+            x-kubernetes-validations:
+            - message: exactly one of realmRef or clusterRealmRef must be set
+              rule: has(self.realmRef) != has(self.clusterRealmRef)
           status:
             description: KeycloakOrganizationStatus defines the observed state of
               KeycloakOrganization

--- a/charts/keycloak-operator/files/crds/keycloak.hostzero.com_keycloakprotocolmappers.yaml
+++ b/charts/keycloak-operator/files/crds/keycloak.hostzero.com_keycloakprotocolmappers.yaml
@@ -90,6 +90,9 @@ spec:
             required:
             - definition
             type: object
+            x-kubernetes-validations:
+            - message: exactly one of clientRef or clientScopeRef must be set
+              rule: has(self.clientRef) != has(self.clientScopeRef)
           status:
             description: KeycloakProtocolMapperStatus defines the observed state of
               KeycloakProtocolMapper

--- a/charts/keycloak-operator/files/crds/keycloak.hostzero.com_keycloakrealms.yaml
+++ b/charts/keycloak-operator/files/crds/keycloak.hostzero.com_keycloakrealms.yaml
@@ -112,6 +112,9 @@ spec:
             required:
             - definition
             type: object
+            x-kubernetes-validations:
+            - message: exactly one of instanceRef or clusterInstanceRef must be set
+              rule: has(self.instanceRef) != has(self.clusterInstanceRef)
           status:
             description: KeycloakRealmStatus defines the observed state of KeycloakRealm
             properties:

--- a/charts/keycloak-operator/files/crds/keycloak.hostzero.com_keycloakrequiredactions.yaml
+++ b/charts/keycloak-operator/files/crds/keycloak.hostzero.com_keycloakrequiredactions.yaml
@@ -90,6 +90,9 @@ spec:
             required:
             - definition
             type: object
+            x-kubernetes-validations:
+            - message: exactly one of realmRef or clusterRealmRef must be set
+              rule: has(self.realmRef) != has(self.clusterRealmRef)
           status:
             description: KeycloakRequiredActionStatus defines the observed state of
               KeycloakRequiredAction

--- a/charts/keycloak-operator/files/crds/keycloak.hostzero.com_keycloakrolemappings.yaml
+++ b/charts/keycloak-operator/files/crds/keycloak.hostzero.com_keycloakrolemappings.yaml
@@ -90,6 +90,9 @@ spec:
                 required:
                 - name
                 type: object
+                x-kubernetes-validations:
+                - message: at most one of clientRef or clientId may be set
+                  rule: '!(has(self.clientRef) && has(self.clientId))'
               roleRef:
                 description: |-
                   RoleRef references an existing KeycloakRole resource
@@ -124,9 +127,15 @@ spec:
                     - name
                     type: object
                 type: object
+                x-kubernetes-validations:
+                - message: exactly one of userRef or groupRef must be set
+                  rule: has(self.userRef) != has(self.groupRef)
             required:
             - subject
             type: object
+            x-kubernetes-validations:
+            - message: exactly one of role or roleRef must be set
+              rule: has(self.role) != has(self.roleRef)
           status:
             description: KeycloakRoleMappingStatus defines the observed state of KeycloakRoleMapping
             properties:

--- a/charts/keycloak-operator/files/crds/keycloak.hostzero.com_keycloakroles.yaml
+++ b/charts/keycloak-operator/files/crds/keycloak.hostzero.com_keycloakroles.yaml
@@ -100,6 +100,9 @@ spec:
             required:
             - definition
             type: object
+            x-kubernetes-validations:
+            - message: exactly one of realmRef or clusterRealmRef must be set
+              rule: has(self.realmRef) != has(self.clusterRealmRef)
           status:
             description: KeycloakRoleStatus defines the observed state of KeycloakRole
             properties:

--- a/charts/keycloak-operator/files/crds/keycloak.hostzero.com_keycloakusers.yaml
+++ b/charts/keycloak-operator/files/crds/keycloak.hostzero.com_keycloakusers.yaml
@@ -133,6 +133,11 @@ spec:
                 - secretName
                 type: object
             type: object
+            x-kubernetes-validations:
+            - message: exactly one of realmRef, clusterRealmRef, or clientRef must
+                be set
+              rule: '(has(self.realmRef) ? 1 : 0) + (has(self.clusterRealmRef) ? 1
+                : 0) + (has(self.clientRef) ? 1 : 0) == 1'
           status:
             description: KeycloakUserStatus defines the observed state of KeycloakUser
             properties:

--- a/config/crd/bases/keycloak.hostzero.com_clusterkeycloakrealms.yaml
+++ b/config/crd/bases/keycloak.hostzero.com_clusterkeycloakrealms.yaml
@@ -125,6 +125,9 @@ spec:
             required:
             - definition
             type: object
+            x-kubernetes-validations:
+            - message: exactly one of instanceRef or clusterInstanceRef must be set
+              rule: has(self.instanceRef) != has(self.clusterInstanceRef)
           status:
             description: ClusterKeycloakRealmStatus defines the observed state of
               ClusterKeycloakRealm

--- a/config/crd/bases/keycloak.hostzero.com_keycloakauthenticationflows.yaml
+++ b/config/crd/bases/keycloak.hostzero.com_keycloakauthenticationflows.yaml
@@ -126,6 +126,9 @@ spec:
             - alias
             - providerId
             type: object
+            x-kubernetes-validations:
+            - message: exactly one of realmRef or clusterRealmRef must be set
+              rule: has(self.realmRef) != has(self.clusterRealmRef)
           status:
             description: KeycloakAuthenticationFlowStatus defines the observed state
               of KeycloakAuthenticationFlow

--- a/config/crd/bases/keycloak.hostzero.com_keycloakclients.yaml
+++ b/config/crd/bases/keycloak.hostzero.com_keycloakclients.yaml
@@ -118,6 +118,9 @@ spec:
                 - name
                 type: object
             type: object
+            x-kubernetes-validations:
+            - message: exactly one of realmRef or clusterRealmRef must be set
+              rule: has(self.realmRef) != has(self.clusterRealmRef)
           status:
             description: KeycloakClientStatus defines the observed state of KeycloakClient
             properties:

--- a/config/crd/bases/keycloak.hostzero.com_keycloakclientscopes.yaml
+++ b/config/crd/bases/keycloak.hostzero.com_keycloakclientscopes.yaml
@@ -85,6 +85,9 @@ spec:
             required:
             - definition
             type: object
+            x-kubernetes-validations:
+            - message: exactly one of realmRef or clusterRealmRef must be set
+              rule: has(self.realmRef) != has(self.clusterRealmRef)
           status:
             description: KeycloakClientScopeStatus defines the observed state of KeycloakClientScope
             properties:

--- a/config/crd/bases/keycloak.hostzero.com_keycloakcomponents.yaml
+++ b/config/crd/bases/keycloak.hostzero.com_keycloakcomponents.yaml
@@ -89,6 +89,9 @@ spec:
             required:
             - definition
             type: object
+            x-kubernetes-validations:
+            - message: exactly one of realmRef or clusterRealmRef must be set
+              rule: has(self.realmRef) != has(self.clusterRealmRef)
           status:
             description: KeycloakComponentStatus defines the observed state of KeycloakComponent
             properties:

--- a/config/crd/bases/keycloak.hostzero.com_keycloakgroups.yaml
+++ b/config/crd/bases/keycloak.hostzero.com_keycloakgroups.yaml
@@ -95,6 +95,9 @@ spec:
             required:
             - definition
             type: object
+            x-kubernetes-validations:
+            - message: exactly one of realmRef or clusterRealmRef must be set
+              rule: has(self.realmRef) != has(self.clusterRealmRef)
           status:
             description: KeycloakGroupStatus defines the observed state of KeycloakGroup
             properties:

--- a/config/crd/bases/keycloak.hostzero.com_keycloakidentityproviders.yaml
+++ b/config/crd/bases/keycloak.hostzero.com_keycloakidentityproviders.yaml
@@ -125,6 +125,9 @@ spec:
             required:
             - definition
             type: object
+            x-kubernetes-validations:
+            - message: exactly one of realmRef or clusterRealmRef must be set
+              rule: has(self.realmRef) != has(self.clusterRealmRef)
           status:
             description: KeycloakIdentityProviderStatus defines the observed state
               of KeycloakIdentityProvider

--- a/config/crd/bases/keycloak.hostzero.com_keycloakorganizations.yaml
+++ b/config/crd/bases/keycloak.hostzero.com_keycloakorganizations.yaml
@@ -87,6 +87,9 @@ spec:
             required:
             - definition
             type: object
+            x-kubernetes-validations:
+            - message: exactly one of realmRef or clusterRealmRef must be set
+              rule: has(self.realmRef) != has(self.clusterRealmRef)
           status:
             description: KeycloakOrganizationStatus defines the observed state of
               KeycloakOrganization

--- a/config/crd/bases/keycloak.hostzero.com_keycloakprotocolmappers.yaml
+++ b/config/crd/bases/keycloak.hostzero.com_keycloakprotocolmappers.yaml
@@ -90,6 +90,9 @@ spec:
             required:
             - definition
             type: object
+            x-kubernetes-validations:
+            - message: exactly one of clientRef or clientScopeRef must be set
+              rule: has(self.clientRef) != has(self.clientScopeRef)
           status:
             description: KeycloakProtocolMapperStatus defines the observed state of
               KeycloakProtocolMapper

--- a/config/crd/bases/keycloak.hostzero.com_keycloakrealms.yaml
+++ b/config/crd/bases/keycloak.hostzero.com_keycloakrealms.yaml
@@ -112,6 +112,9 @@ spec:
             required:
             - definition
             type: object
+            x-kubernetes-validations:
+            - message: exactly one of instanceRef or clusterInstanceRef must be set
+              rule: has(self.instanceRef) != has(self.clusterInstanceRef)
           status:
             description: KeycloakRealmStatus defines the observed state of KeycloakRealm
             properties:

--- a/config/crd/bases/keycloak.hostzero.com_keycloakrequiredactions.yaml
+++ b/config/crd/bases/keycloak.hostzero.com_keycloakrequiredactions.yaml
@@ -90,6 +90,9 @@ spec:
             required:
             - definition
             type: object
+            x-kubernetes-validations:
+            - message: exactly one of realmRef or clusterRealmRef must be set
+              rule: has(self.realmRef) != has(self.clusterRealmRef)
           status:
             description: KeycloakRequiredActionStatus defines the observed state of
               KeycloakRequiredAction

--- a/config/crd/bases/keycloak.hostzero.com_keycloakrolemappings.yaml
+++ b/config/crd/bases/keycloak.hostzero.com_keycloakrolemappings.yaml
@@ -90,6 +90,9 @@ spec:
                 required:
                 - name
                 type: object
+                x-kubernetes-validations:
+                - message: at most one of clientRef or clientId may be set
+                  rule: '!(has(self.clientRef) && has(self.clientId))'
               roleRef:
                 description: |-
                   RoleRef references an existing KeycloakRole resource
@@ -124,9 +127,15 @@ spec:
                     - name
                     type: object
                 type: object
+                x-kubernetes-validations:
+                - message: exactly one of userRef or groupRef must be set
+                  rule: has(self.userRef) != has(self.groupRef)
             required:
             - subject
             type: object
+            x-kubernetes-validations:
+            - message: exactly one of role or roleRef must be set
+              rule: has(self.role) != has(self.roleRef)
           status:
             description: KeycloakRoleMappingStatus defines the observed state of KeycloakRoleMapping
             properties:

--- a/config/crd/bases/keycloak.hostzero.com_keycloakroles.yaml
+++ b/config/crd/bases/keycloak.hostzero.com_keycloakroles.yaml
@@ -100,6 +100,9 @@ spec:
             required:
             - definition
             type: object
+            x-kubernetes-validations:
+            - message: exactly one of realmRef or clusterRealmRef must be set
+              rule: has(self.realmRef) != has(self.clusterRealmRef)
           status:
             description: KeycloakRoleStatus defines the observed state of KeycloakRole
             properties:

--- a/config/crd/bases/keycloak.hostzero.com_keycloakusers.yaml
+++ b/config/crd/bases/keycloak.hostzero.com_keycloakusers.yaml
@@ -133,6 +133,11 @@ spec:
                 - secretName
                 type: object
             type: object
+            x-kubernetes-validations:
+            - message: exactly one of realmRef, clusterRealmRef, or clientRef must
+                be set
+              rule: '(has(self.realmRef) ? 1 : 0) + (has(self.clusterRealmRef) ? 1
+                : 0) + (has(self.clientRef) ? 1 : 0) == 1'
           status:
             description: KeycloakUserStatus defines the observed state of KeycloakUser
             properties:


### PR DESCRIPTION
## Description

Fixes missing CRD admission validation for mutually exclusive resource references.

Several CRD specs documented that exactly one reference must be set, but the generated CRD schemas did not enforce that requirement. For example, resources could be accepted with both `realmRef` and `clusterRealmRef`, or with neither set. Controllers then had to resolve ambiguous input themselves, often by silently preferring one field or reporting the error later during reconciliation.

This adds CEL validation rules to reject invalid reference combinations at Kubernetes admission time, including:

- `realmRef` vs `clusterRealmRef` on realm-scoped resources
- `instanceRef` vs `clusterInstanceRef` on realm resources
- `clientRef` vs `clientScopeRef` on protocol mappers
- `role` vs `roleRef` on role mappings
- `userRef` vs `groupRef` on role mapping subjects
- exactly one of `realmRef`, `clusterRealmRef`, or `clientRef` on users
- at most one of `clientRef` or `clientId` for inline role definitions

The CRD bases and Helm CRD copies were regenerated.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Relates to invalid CRs being accepted even though the API documentation says exactly one reference must be specified.

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`make test`)
- [ ] I have updated the documentation if needed
- [ ] I have updated the CHANGELOG.md if this is a user-facing change

## Testing

Ran the full non-e2e test suite:

```bash
make test
```

This includes an envtest-backed API admission test that installs the generated CRDs into a real Kubernetes API server and verifies valid/invalid CRs through Kubernetes admission.

Ran the targeted validation test directly:

```bash
KUBEBUILDER_ASSETS="$(./bin/setup-envtest use 1.31.0 --bin-dir "$(pwd)/bin" -p path)" \
  go test -v ./api/v1beta1 \
  -run TestCRDReferenceChoiceValidation \
  -count=1
```

The targeted test verifies these cases:

- valid `KeycloakClient` with exactly one realm reference is accepted
- invalid `KeycloakClient` with missing or conflicting realm references is rejected
- invalid `KeycloakUser` with multiple target references is rejected
- invalid `KeycloakProtocolMapper` with both parent references is rejected
- invalid `KeycloakRoleMapping` with both role sources is rejected
- invalid `KeycloakRoleMapping` with both subject sources is rejected
- invalid inline role definition with both `clientRef` and `clientId` is rejected

### Manual verification

The generated CRDs were also accepted by Kubernetes dry-run validation:

```bash
kubectl apply --dry-run=client -f config/crd/bases
kubectl apply --dry-run=server -f config/crd/bases
```

The server dry-run accepted the generated CRDs. It only emitted existing `last-applied-configuration` warnings for CRDs already present in the cluster.

## Additional Notes

This enforces constraints that were already documented in the API comments, so invalid manifests fail earlier with clearer admission errors instead of producing ambiguous controller behavior later.
