### PR TITLE
fix: normalize Keycloak client configuration

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - create

--- a/internal/controller/keycloakinstance_controller.go
+++ b/internal/controller/keycloakinstance_controller.go
@@ -63,6 +63,7 @@ type KeycloakInstanceReconciler struct {
 // +kubebuilder:rbac:groups=keycloak.hostzero.com,resources=keycloakinstances/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=keycloak.hostzero.com,resources=keycloakinstances/finalizers,verbs=update
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 // Reconcile handles KeycloakInstance reconciliation
 func (r *KeycloakInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/internal/keycloak/client.go
+++ b/internal/keycloak/client.go
@@ -64,9 +64,7 @@ type TokenResponse struct {
 
 // NewClient creates a new Keycloak client
 func NewClient(cfg Config, log logr.Logger) *Client {
-	if cfg.Realm == "" {
-		cfg.Realm = "master"
-	}
+	cfg = normalizeConfig(cfg)
 
 	httpClient := resty.New().
 		SetTimeout(30 * time.Second).
@@ -77,7 +75,7 @@ func NewClient(cfg Config, log logr.Logger) *Client {
 	}
 
 	return &Client{
-		baseURL:            strings.TrimSuffix(cfg.BaseURL, "/"),
+		baseURL:            cfg.BaseURL,
 		realm:              cfg.Realm,
 		username:           cfg.Username,
 		password:           cfg.Password,
@@ -88,6 +86,14 @@ func NewClient(cfg Config, log logr.Logger) *Client {
 		httpClient:         httpClient,
 		log:                log.WithName("keycloak-client"),
 	}
+}
+
+func normalizeConfig(cfg Config) Config {
+	cfg.BaseURL = strings.TrimSuffix(cfg.BaseURL, "/")
+	if cfg.Realm == "" {
+		cfg.Realm = "master"
+	}
+	return cfg
 }
 
 // buildTLSConfig returns a *tls.Config when the cfg requests TLS customisation,
@@ -2131,6 +2137,7 @@ func (m *ClientManager) GetOrCreateClient(instanceName string, cfg Config) *Clie
 
 // configChanged checks if the config has changed from what's in the existing client
 func (m *ClientManager) configChanged(client *Client, cfg Config) bool {
+	cfg = normalizeConfig(cfg)
 	return client.baseURL != cfg.BaseURL ||
 		client.username != cfg.Username ||
 		client.password != cfg.Password ||

--- a/internal/keycloak/client_tls_test.go
+++ b/internal/keycloak/client_tls_test.go
@@ -140,6 +140,28 @@ func TestClient_HTTPSInsecureSkipVerify(t *testing.T) {
 	}
 }
 
+func TestClientManager_ConfigChanged_NormalizesDefaults(t *testing.T) {
+	mgr := NewClientManager(testr.New(t))
+	base := Config{BaseURL: "https://kc/", Username: "u", Password: "p"}
+	c := mgr.GetOrCreateClient("kc/i", base)
+
+	if mgr.configChanged(c, base) {
+		t.Fatal("identical config should not be detected as changed")
+	}
+
+	withoutTrailingSlash := base
+	withoutTrailingSlash.BaseURL = "https://kc"
+	if mgr.configChanged(c, withoutTrailingSlash) {
+		t.Fatal("trailing-slash equivalent BaseURL should not be detected as changed")
+	}
+
+	withExplicitDefaultRealm := base
+	withExplicitDefaultRealm.Realm = "master"
+	if mgr.configChanged(c, withExplicitDefaultRealm) {
+		t.Fatal("explicit default realm should not be detected as changed")
+	}
+}
+
 func TestClientManager_ConfigChanged_TLSFields(t *testing.T) {
 	mgr := NewClientManager(testr.New(t))
 	base := Config{BaseURL: "https://kc", Username: "u", Password: "p", Realm: "master"}


### PR DESCRIPTION
## Description

Fixes two general reconciliation issues found while reviewing operator behavior.

First, the Keycloak client manager compared cached client state against the raw config input. `NewClient` defaulted an empty realm to `master` and trimmed trailing slashes from `baseUrl`, but `configChanged` compared the cached normalized values against the unnormalized config. This could make equivalent configs look different and recreate Keycloak clients unnecessarily, losing cached tokens and causing avoidable authentication calls.

This changes client config comparison to use the same normalization as client construction:

- trim trailing slashes from `baseUrl`
- default an empty admin realm to `master`

Second, the API and config resolution code support `tls.caCert.configMapRef`, but the generated manager RBAC did not grant ConfigMap read access. This adds the missing `configmaps` `get/list/watch` RBAC rule so ConfigMap-backed CA bundles can be resolved.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Relates to unnecessary Keycloak client recreation for equivalent client configs and failed `tls.caCert.configMapRef` resolution due to missing RBAC.

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`make test`)
- [ ] I have updated the documentation if needed
- [ ] I have updated the CHANGELOG.md if this is a user-facing change

## Testing

Ran targeted tests:

```bash
go test ./internal/keycloak ./internal/controller
```

Ran the full non-e2e test suite:

```bash
make test
```

The new unit test verifies that the client manager treats these configs as equivalent instead of changed:

- `https://kc/` and `https://kc`
- omitted realm and explicit `master` realm

### Manual verification

Regenerated RBAC manifests with:

```bash
make manifests
```

Confirmed the generated manager role now includes ConfigMap read permissions:

```yaml
resources:
  - configmaps
verbs:
  - get
  - list
  - watch
```

## Additional Notes

The Helm chart cluster role already had ConfigMap permissions for leader election, but the generated `config/rbac/role.yaml` did not. This keeps the generated RBAC aligned with the code paths that read CA bundles from ConfigMaps.
