### PR TITLE
fix: stop self-triggered reconcile hot loop from unconditional status…

### DIFF
--- a/docs/src/development/contributing.md
+++ b/docs/src/development/contributing.md
@@ -59,6 +59,7 @@ Follow [Conventional Commits](https://www.conventionalcommits.org/):
 - Add comments for exported types/functions
 - Keep functions focused and small
 - When adding CRD fields, follow the [Spec Layout](../crds.md#spec-layout) rules for what goes in spec versus `definition`
+- Controllers must end `updateStatus` with `writeStatusIfChanged` and build the Ready condition with `setReadyCondition`. Writing status unconditionally re-triggers the controller's own watch and produces a reconcile hot loop instead of honouring the sync period
 
 ### Testing Requirements
 

--- a/internal/controller/clusterkeycloakinstance_controller.go
+++ b/internal/controller/clusterkeycloakinstance_controller.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -123,39 +122,9 @@ func (r *ClusterKeycloakInstanceReconciler) updateStatus(ctx context.Context, in
 		instance.Status.Version = version
 	}
 
-	// Update conditions
-	condition := metav1.Condition{
-		Type:               "Ready",
-		Status:             metav1.ConditionFalse,
-		Reason:             status,
-		Message:            message,
-		LastTransitionTime: metav1.Now(),
-	}
-	if ready {
-		condition.Status = metav1.ConditionTrue
-	}
+	instance.Status.Conditions = setReadyCondition(instance.Status.Conditions, ready, status, message)
 
-	// Update or add condition
-	found := false
-	for i, c := range instance.Status.Conditions {
-		if c.Type == "Ready" {
-			instance.Status.Conditions[i] = condition
-			found = true
-			break
-		}
-	}
-	if !found {
-		instance.Status.Conditions = append(instance.Status.Conditions, condition)
-	}
-
-	if err := r.Status().Update(ctx, instance); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	if ready {
-		return ctrl.Result{RequeueAfter: GetSyncPeriod()}, nil
-	}
-	return ctrl.Result{RequeueAfter: ErrorRequeueDelay}, nil
+	return writeStatusIfChanged(ctx, r.Client, instance, ready)
 }
 
 // SetupWithManager sets up the controller with the Manager

--- a/internal/controller/clusterkeycloakrealm_controller.go
+++ b/internal/controller/clusterkeycloakrealm_controller.go
@@ -8,7 +8,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -254,69 +253,14 @@ func (r *ClusterKeycloakRealmReconciler) deleteRealm(ctx context.Context, realm 
 }
 
 func (r *ClusterKeycloakRealmReconciler) updateStatus(ctx context.Context, realm *keycloakv1beta1.ClusterKeycloakRealm, ready bool, status, message string, instanceRef *keycloakv1beta1.InstanceRef) (ctrl.Result, error) {
-	desiredConditionStatus := metav1.ConditionFalse
-	if ready {
-		desiredConditionStatus = metav1.ConditionTrue
-	}
-
-	// Detect whether any user-visible status field actually changed
-	statusChanged := realm.Status.Ready != ready ||
-		realm.Status.Status != status ||
-		realm.Status.Message != message
-
-	conditionChanged := true
-	for _, c := range realm.Status.Conditions {
-		if c.Type == "Ready" && c.Status == desiredConditionStatus && c.Reason == status && c.Message == message {
-			conditionChanged = false
-			break
-		}
-	}
-
-	if !statusChanged && !conditionChanged {
-		// Nothing changed — skip the API write to avoid triggering a watch-event reconcile loop
-		if ready {
-			return ctrl.Result{RequeueAfter: GetSyncPeriod()}, nil
-		}
-		return ctrl.Result{RequeueAfter: ErrorRequeueDelay}, nil
-	}
-
 	realm.Status.Ready = ready
 	realm.Status.Status = status
 	realm.Status.Message = message
 	realm.Status.Instance = instanceRef
 
-	condition := metav1.Condition{
-		Type:               "Ready",
-		Status:             desiredConditionStatus,
-		Reason:             status,
-		Message:            message,
-		LastTransitionTime: metav1.Now(),
-	}
+	realm.Status.Conditions = setReadyCondition(realm.Status.Conditions, ready, status, message)
 
-	found := false
-	for i, c := range realm.Status.Conditions {
-		if c.Type == "Ready" {
-			// Preserve LastTransitionTime if status did not flip
-			if c.Status == desiredConditionStatus {
-				condition.LastTransitionTime = c.LastTransitionTime
-			}
-			realm.Status.Conditions[i] = condition
-			found = true
-			break
-		}
-	}
-	if !found {
-		realm.Status.Conditions = append(realm.Status.Conditions, condition)
-	}
-
-	if err := r.Status().Update(ctx, realm); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	if ready {
-		return ctrl.Result{RequeueAfter: GetSyncPeriod()}, nil
-	}
-	return ctrl.Result{RequeueAfter: ErrorRequeueDelay}, nil
+	return writeStatusIfChanged(ctx, r.Client, realm, ready)
 }
 
 func (r *ClusterKeycloakRealmReconciler) resolveSmtpSecret(ctx context.Context, realm *keycloakv1beta1.ClusterKeycloakRealm) (string, string, error) {

--- a/internal/controller/keycloak_config.go
+++ b/internal/controller/keycloak_config.go
@@ -8,37 +8,12 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	keycloakv1beta1 "github.com/Hostzero-GmbH/keycloak-operator/api/v1beta1"
 	"github.com/Hostzero-GmbH/keycloak-operator/internal/keycloak"
 )
-
-const ReadyConditionType = "Ready"
-
-// setReadyCondition adds or updates the "Ready" condition in the supplied slice.
-func setReadyCondition(conditions []metav1.Condition, ready bool, reason, message string) []metav1.Condition {
-	condition := metav1.Condition{
-		Type:               ReadyConditionType,
-		Status:             metav1.ConditionFalse,
-		Reason:             reason,
-		Message:            message,
-		LastTransitionTime: metav1.Now(),
-	}
-	if ready {
-		condition.Status = metav1.ConditionTrue
-	}
-
-	for i, c := range conditions {
-		if c.Type == ReadyConditionType {
-			conditions[i] = condition
-			return conditions
-		}
-	}
-	return append(conditions, condition)
-}
 
 // Default timing constants
 const (

--- a/internal/controller/keycloak_config_test.go
+++ b/internal/controller/keycloak_config_test.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestMergeIDIntoDefinition(t *testing.T) {
@@ -793,74 +791,6 @@ func TestStripRealmFlowBindingsForCreateNoBindings(t *testing.T) {
 	if string(result) != string(definition) {
 		t.Fatalf("expected original definition, got %s", string(result))
 	}
-}
-
-func TestSetReadyCondition(t *testing.T) {
-	t.Run("appends Ready condition when none exists", func(t *testing.T) {
-		out := setReadyCondition(nil, true, "Ready", "all good")
-		if len(out) != 1 {
-			t.Fatalf("expected 1 condition, got %d", len(out))
-		}
-		if out[0].Type != ReadyConditionType {
-			t.Errorf("expected condition type %q, got %q", ReadyConditionType, out[0].Type)
-		}
-		if out[0].Status != metav1.ConditionTrue {
-			t.Errorf("expected ConditionTrue, got %q", out[0].Status)
-		}
-		if out[0].Reason != "Ready" {
-			t.Errorf("expected reason %q, got %q", "Ready", out[0].Reason)
-		}
-		if out[0].Message != "all good" {
-			t.Errorf("expected message %q, got %q", "all good", out[0].Message)
-		}
-		if out[0].LastTransitionTime.IsZero() {
-			t.Error("expected LastTransitionTime to be set")
-		}
-	})
-
-	t.Run("sets ConditionFalse when not ready", func(t *testing.T) {
-		out := setReadyCondition(nil, false, "InvalidSpec", "missing field")
-		if out[0].Status != metav1.ConditionFalse {
-			t.Errorf("expected ConditionFalse, got %q", out[0].Status)
-		}
-		if out[0].Reason != "InvalidSpec" {
-			t.Errorf("expected reason %q, got %q", "InvalidSpec", out[0].Reason)
-		}
-	})
-
-	t.Run("replaces existing Ready condition in place", func(t *testing.T) {
-		existing := []metav1.Condition{
-			{Type: ReadyConditionType, Status: metav1.ConditionFalse, Reason: "Pending", Message: "old"},
-			{Type: "OtherCondition", Status: metav1.ConditionTrue, Reason: "X", Message: "untouched"},
-		}
-		out := setReadyCondition(existing, true, "Ready", "now ok")
-		if len(out) != 2 {
-			t.Fatalf("expected 2 conditions, got %d", len(out))
-		}
-		if out[0].Status != metav1.ConditionTrue || out[0].Reason != "Ready" || out[0].Message != "now ok" {
-			t.Errorf("Ready condition was not updated correctly: %+v", out[0])
-		}
-		if out[1].Type != "OtherCondition" || out[1].Reason != "X" || out[1].Message != "untouched" {
-			t.Errorf("non-Ready condition should be left alone, got %+v", out[1])
-		}
-	})
-
-	t.Run("preserves order when Ready is not first", func(t *testing.T) {
-		existing := []metav1.Condition{
-			{Type: "OtherCondition", Status: metav1.ConditionTrue, Reason: "X", Message: "untouched"},
-			{Type: ReadyConditionType, Status: metav1.ConditionFalse, Reason: "Pending", Message: "old"},
-		}
-		out := setReadyCondition(existing, true, "Ready", "ok")
-		if len(out) != 2 {
-			t.Fatalf("expected 2 conditions, got %d", len(out))
-		}
-		if out[0].Type != "OtherCondition" {
-			t.Errorf("expected first condition to remain OtherCondition, got %q", out[0].Type)
-		}
-		if out[1].Type != ReadyConditionType || out[1].Status != metav1.ConditionTrue {
-			t.Errorf("expected Ready condition at index 1 to be true, got %+v", out[1])
-		}
-	})
 }
 
 func TestRealmDefinitionsMatch_SmtpPasswordMasked(t *testing.T) {

--- a/internal/controller/keycloakauthenticationflow_controller.go
+++ b/internal/controller/keycloakauthenticationflow_controller.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -983,37 +982,9 @@ func (r *KeycloakAuthenticationFlowReconciler) updateStatus(ctx context.Context,
 		flow.Status.ObservedGeneration = flow.Generation
 	}
 
-	condition := metav1.Condition{
-		Type:               "Ready",
-		Status:             metav1.ConditionFalse,
-		Reason:             status,
-		Message:            message,
-		LastTransitionTime: metav1.Now(),
-	}
-	if ready {
-		condition.Status = metav1.ConditionTrue
-	}
+	flow.Status.Conditions = setReadyCondition(flow.Status.Conditions, ready, status, message)
 
-	found := false
-	for i, c := range flow.Status.Conditions {
-		if c.Type == "Ready" {
-			flow.Status.Conditions[i] = condition
-			found = true
-			break
-		}
-	}
-	if !found {
-		flow.Status.Conditions = append(flow.Status.Conditions, condition)
-	}
-
-	if err := r.Status().Update(ctx, flow); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	if ready {
-		return ctrl.Result{RequeueAfter: GetSyncPeriod()}, nil
-	}
-	return ctrl.Result{RequeueAfter: ErrorRequeueDelay}, nil
+	return writeStatusIfChanged(ctx, r.Client, flow, ready)
 }
 
 // SetupWithManager sets up the controller with the Manager

--- a/internal/controller/keycloakclient_controller.go
+++ b/internal/controller/keycloakclient_controller.go
@@ -605,37 +605,6 @@ func (r *KeycloakClientReconciler) deleteClient(ctx context.Context, kcClient *k
 }
 
 func (r *KeycloakClientReconciler) updateStatus(ctx context.Context, kcClient *keycloakv1beta1.KeycloakClient, ready bool, status, message, clientUUID string, instanceRef *keycloakv1beta1.InstanceRef, realmRef *keycloakv1beta1.RealmRef) (ctrl.Result, error) {
-	// Determine desired condition status
-	desiredConditionStatus := metav1.ConditionFalse
-	if ready {
-		desiredConditionStatus = metav1.ConditionTrue
-	}
-
-	// Check if status actually changed
-	statusChanged := kcClient.Status.Ready != ready ||
-		kcClient.Status.Status != status ||
-		kcClient.Status.Message != message ||
-		kcClient.Status.ClientUUID != clientUUID
-
-	conditionChanged := true
-	for _, c := range kcClient.Status.Conditions {
-		if c.Type == "Ready" && c.Status == desiredConditionStatus && c.Reason == status && c.Message == message {
-			conditionChanged = false
-			break
-		}
-	}
-
-	// Check if observed generation changed
-	generationChanged := ready && kcClient.Status.ObservedGeneration != kcClient.Generation
-
-	if !statusChanged && !conditionChanged && !generationChanged {
-		// Nothing changed, just requeue without writing to API
-		if ready {
-			return ctrl.Result{RequeueAfter: GetSyncPeriod()}, nil
-		}
-		return ctrl.Result{RequeueAfter: ErrorRequeueDelay}, nil
-	}
-
 	kcClient.Status.Ready = ready
 	kcClient.Status.Status = status
 	kcClient.Status.Message = message
@@ -648,40 +617,9 @@ func (r *KeycloakClientReconciler) updateStatus(ctx context.Context, kcClient *k
 		kcClient.Status.ObservedGeneration = kcClient.Generation
 	}
 
-	// Update conditions
-	condition := metav1.Condition{
-		Type:               "Ready",
-		Status:             desiredConditionStatus,
-		Reason:             status,
-		Message:            message,
-		LastTransitionTime: metav1.Now(),
-	}
+	kcClient.Status.Conditions = setReadyCondition(kcClient.Status.Conditions, ready, status, message)
 
-	// Update or add condition
-	found := false
-	for i, c := range kcClient.Status.Conditions {
-		if c.Type == "Ready" {
-			// Preserve LastTransitionTime if status didn't change
-			if c.Status == desiredConditionStatus {
-				condition.LastTransitionTime = c.LastTransitionTime
-			}
-			kcClient.Status.Conditions[i] = condition
-			found = true
-			break
-		}
-	}
-	if !found {
-		kcClient.Status.Conditions = append(kcClient.Status.Conditions, condition)
-	}
-
-	if err := r.Status().Update(ctx, kcClient); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	if ready {
-		return ctrl.Result{RequeueAfter: GetSyncPeriod()}, nil
-	}
-	return ctrl.Result{RequeueAfter: ErrorRequeueDelay}, nil
+	return writeStatusIfChanged(ctx, r.Client, kcClient, ready)
 }
 
 // definitionsMatch compares desired definition against the current state in Keycloak.

--- a/internal/controller/keycloakclientscope_controller.go
+++ b/internal/controller/keycloakclientscope_controller.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -286,38 +285,9 @@ func (r *KeycloakClientScopeReconciler) updateStatus(ctx context.Context, client
 	clientScope.Status.Status = status
 	clientScope.Status.Message = message
 
-	// Update conditions
-	condition := metav1.Condition{
-		Type:               "Ready",
-		Status:             metav1.ConditionFalse,
-		Reason:             status,
-		Message:            message,
-		LastTransitionTime: metav1.Now(),
-	}
-	if ready {
-		condition.Status = metav1.ConditionTrue
-	}
+	clientScope.Status.Conditions = setReadyCondition(clientScope.Status.Conditions, ready, status, message)
 
-	found := false
-	for i, c := range clientScope.Status.Conditions {
-		if c.Type == "Ready" {
-			clientScope.Status.Conditions[i] = condition
-			found = true
-			break
-		}
-	}
-	if !found {
-		clientScope.Status.Conditions = append(clientScope.Status.Conditions, condition)
-	}
-
-	if err := r.Status().Update(ctx, clientScope); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	if ready {
-		return ctrl.Result{RequeueAfter: GetSyncPeriod()}, nil
-	}
-	return ctrl.Result{RequeueAfter: ErrorRequeueDelay}, nil
+	return writeStatusIfChanged(ctx, r.Client, clientScope, ready)
 }
 
 // SetupWithManager sets up the controller with the Manager

--- a/internal/controller/keycloakcomponent_controller.go
+++ b/internal/controller/keycloakcomponent_controller.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -455,37 +454,9 @@ func (r *KeycloakComponentReconciler) updateStatus(ctx context.Context, componen
 		component.Status.ObservedGeneration = component.Generation
 	}
 
-	condition := metav1.Condition{
-		Type:               "Ready",
-		Status:             metav1.ConditionFalse,
-		Reason:             status,
-		Message:            message,
-		LastTransitionTime: metav1.Now(),
-	}
-	if ready {
-		condition.Status = metav1.ConditionTrue
-	}
+	component.Status.Conditions = setReadyCondition(component.Status.Conditions, ready, status, message)
 
-	found := false
-	for i, c := range component.Status.Conditions {
-		if c.Type == "Ready" {
-			component.Status.Conditions[i] = condition
-			found = true
-			break
-		}
-	}
-	if !found {
-		component.Status.Conditions = append(component.Status.Conditions, condition)
-	}
-
-	if err := r.Status().Update(ctx, component); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	if ready {
-		return ctrl.Result{RequeueAfter: GetSyncPeriod()}, nil
-	}
-	return ctrl.Result{RequeueAfter: ErrorRequeueDelay}, nil
+	return writeStatusIfChanged(ctx, r.Client, component, ready)
 }
 
 // SetupWithManager sets up the controller with the Manager

--- a/internal/controller/keycloakgroup_controller.go
+++ b/internal/controller/keycloakgroup_controller.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -324,38 +323,9 @@ func (r *KeycloakGroupReconciler) updateStatus(ctx context.Context, group *keycl
 		group.Status.GroupID = groupID
 	}
 
-	// Update conditions
-	condition := metav1.Condition{
-		Type:               "Ready",
-		Status:             metav1.ConditionFalse,
-		Reason:             status,
-		Message:            message,
-		LastTransitionTime: metav1.Now(),
-	}
-	if ready {
-		condition.Status = metav1.ConditionTrue
-	}
+	group.Status.Conditions = setReadyCondition(group.Status.Conditions, ready, status, message)
 
-	found := false
-	for i, c := range group.Status.Conditions {
-		if c.Type == "Ready" {
-			group.Status.Conditions[i] = condition
-			found = true
-			break
-		}
-	}
-	if !found {
-		group.Status.Conditions = append(group.Status.Conditions, condition)
-	}
-
-	if err := r.Status().Update(ctx, group); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	if ready {
-		return ctrl.Result{RequeueAfter: GetSyncPeriod()}, nil
-	}
-	return ctrl.Result{RequeueAfter: ErrorRequeueDelay}, nil
+	return writeStatusIfChanged(ctx, r.Client, group, ready)
 }
 
 // SetupWithManager sets up the controller with the Manager

--- a/internal/controller/keycloakidentityprovider_controller.go
+++ b/internal/controller/keycloakidentityprovider_controller.go
@@ -8,7 +8,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -223,38 +222,9 @@ func (r *KeycloakIdentityProviderReconciler) updateStatus(ctx context.Context, i
 	idp.Status.Status = status
 	idp.Status.Message = message
 
-	// Update conditions
-	condition := metav1.Condition{
-		Type:               "Ready",
-		Status:             metav1.ConditionFalse,
-		Reason:             status,
-		Message:            message,
-		LastTransitionTime: metav1.Now(),
-	}
-	if ready {
-		condition.Status = metav1.ConditionTrue
-	}
+	idp.Status.Conditions = setReadyCondition(idp.Status.Conditions, ready, status, message)
 
-	found := false
-	for i, c := range idp.Status.Conditions {
-		if c.Type == "Ready" {
-			idp.Status.Conditions[i] = condition
-			found = true
-			break
-		}
-	}
-	if !found {
-		idp.Status.Conditions = append(idp.Status.Conditions, condition)
-	}
-
-	if err := r.Status().Update(ctx, idp); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	if ready {
-		return ctrl.Result{RequeueAfter: GetSyncPeriod()}, nil
-	}
-	return ctrl.Result{RequeueAfter: ErrorRequeueDelay}, nil
+	return writeStatusIfChanged(ctx, r.Client, idp, ready)
 }
 
 // resolveConfigSecret reads all keys from a referenced Secret (upstream ConfigSecretRef path).

--- a/internal/controller/keycloakidentityprovidermapper_controller.go
+++ b/internal/controller/keycloakidentityprovidermapper_controller.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -240,37 +239,9 @@ func (r *KeycloakIdentityProviderMapperReconciler) updateStatus(ctx context.Cont
 		mapper.Status.ObservedGeneration = mapper.Generation
 	}
 
-	condition := metav1.Condition{
-		Type:               "Ready",
-		Status:             metav1.ConditionFalse,
-		Reason:             status,
-		Message:            message,
-		LastTransitionTime: metav1.Now(),
-	}
-	if ready {
-		condition.Status = metav1.ConditionTrue
-	}
+	mapper.Status.Conditions = setReadyCondition(mapper.Status.Conditions, ready, status, message)
 
-	found := false
-	for i, c := range mapper.Status.Conditions {
-		if c.Type == "Ready" {
-			mapper.Status.Conditions[i] = condition
-			found = true
-			break
-		}
-	}
-	if !found {
-		mapper.Status.Conditions = append(mapper.Status.Conditions, condition)
-	}
-
-	if err := r.Status().Update(ctx, mapper); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	if ready {
-		return ctrl.Result{RequeueAfter: GetSyncPeriod()}, nil
-	}
-	return ctrl.Result{RequeueAfter: ErrorRequeueDelay}, nil
+	return writeStatusIfChanged(ctx, r.Client, mapper, ready)
 }
 
 // SetupWithManager sets up the controller with the Manager

--- a/internal/controller/keycloakinstance_controller.go
+++ b/internal/controller/keycloakinstance_controller.go
@@ -9,7 +9,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -170,39 +169,9 @@ func (r *KeycloakInstanceReconciler) updateStatus(ctx context.Context, instance 
 		instance.Status.Version = version
 	}
 
-	// Update conditions
-	condition := metav1.Condition{
-		Type:               "Ready",
-		Status:             metav1.ConditionFalse,
-		Reason:             status,
-		Message:            message,
-		LastTransitionTime: metav1.Now(),
-	}
-	if ready {
-		condition.Status = metav1.ConditionTrue
-	}
+	instance.Status.Conditions = setReadyCondition(instance.Status.Conditions, ready, status, message)
 
-	// Update or add condition
-	found := false
-	for i, c := range instance.Status.Conditions {
-		if c.Type == "Ready" {
-			instance.Status.Conditions[i] = condition
-			found = true
-			break
-		}
-	}
-	if !found {
-		instance.Status.Conditions = append(instance.Status.Conditions, condition)
-	}
-
-	if err := r.Status().Update(ctx, instance); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	if ready {
-		return ctrl.Result{RequeueAfter: GetSyncPeriod()}, nil
-	}
-	return ctrl.Result{RequeueAfter: ErrorRequeueDelay}, nil
+	return writeStatusIfChanged(ctx, r.Client, instance, ready)
 }
 
 // SetupWithManager sets up the controller with the Manager

--- a/internal/controller/keycloakorganization_controller.go
+++ b/internal/controller/keycloakorganization_controller.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -341,38 +340,9 @@ func (r *KeycloakOrganizationReconciler) updateStatus(ctx context.Context, org *
 		org.Status.ObservedGeneration = org.Generation
 	}
 
-	// Update conditions
-	condition := metav1.Condition{
-		Type:               "Ready",
-		Status:             metav1.ConditionFalse,
-		Reason:             status,
-		Message:            message,
-		LastTransitionTime: metav1.Now(),
-	}
-	if ready {
-		condition.Status = metav1.ConditionTrue
-	}
+	org.Status.Conditions = setReadyCondition(org.Status.Conditions, ready, status, message)
 
-	found := false
-	for i, c := range org.Status.Conditions {
-		if c.Type == "Ready" {
-			org.Status.Conditions[i] = condition
-			found = true
-			break
-		}
-	}
-	if !found {
-		org.Status.Conditions = append(org.Status.Conditions, condition)
-	}
-
-	if err := r.Status().Update(ctx, org); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	if ready {
-		return ctrl.Result{RequeueAfter: GetSyncPeriod()}, nil
-	}
-	return ctrl.Result{RequeueAfter: ErrorRequeueDelay}, nil
+	return writeStatusIfChanged(ctx, r.Client, org, ready)
 }
 
 // SetupWithManager sets up the controller with the Manager

--- a/internal/controller/keycloakprotocolmapper_controller.go
+++ b/internal/controller/keycloakprotocolmapper_controller.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -405,37 +404,9 @@ func (r *KeycloakProtocolMapperReconciler) updateStatus(ctx context.Context, map
 		mapper.Status.ObservedGeneration = mapper.Generation
 	}
 
-	condition := metav1.Condition{
-		Type:               "Ready",
-		Status:             metav1.ConditionFalse,
-		Reason:             status,
-		Message:            message,
-		LastTransitionTime: metav1.Now(),
-	}
-	if ready {
-		condition.Status = metav1.ConditionTrue
-	}
+	mapper.Status.Conditions = setReadyCondition(mapper.Status.Conditions, ready, status, message)
 
-	found := false
-	for i, c := range mapper.Status.Conditions {
-		if c.Type == "Ready" {
-			mapper.Status.Conditions[i] = condition
-			found = true
-			break
-		}
-	}
-	if !found {
-		mapper.Status.Conditions = append(mapper.Status.Conditions, condition)
-	}
-
-	if err := r.Status().Update(ctx, mapper); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	if ready {
-		return ctrl.Result{RequeueAfter: GetSyncPeriod()}, nil
-	}
-	return ctrl.Result{RequeueAfter: ErrorRequeueDelay}, nil
+	return writeStatusIfChanged(ctx, r.Client, mapper, ready)
 }
 
 // extractIDFromPath extracts the ID from a resource path

--- a/internal/controller/keycloakrealm_controller.go
+++ b/internal/controller/keycloakrealm_controller.go
@@ -8,7 +8,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -282,69 +281,14 @@ func (r *KeycloakRealmReconciler) deleteRealm(ctx context.Context, realm *keyclo
 }
 
 func (r *KeycloakRealmReconciler) updateStatus(ctx context.Context, realm *keycloakv1beta1.KeycloakRealm, ready bool, status, message string, instanceRef *keycloakv1beta1.InstanceRef) (ctrl.Result, error) {
-	desiredConditionStatus := metav1.ConditionFalse
-	if ready {
-		desiredConditionStatus = metav1.ConditionTrue
-	}
-
-	// Detect whether any user-visible status field actually changed
-	statusChanged := realm.Status.Ready != ready ||
-		realm.Status.Status != status ||
-		realm.Status.Message != message
-
-	conditionChanged := true
-	for _, c := range realm.Status.Conditions {
-		if c.Type == "Ready" && c.Status == desiredConditionStatus && c.Reason == status && c.Message == message {
-			conditionChanged = false
-			break
-		}
-	}
-
-	if !statusChanged && !conditionChanged {
-		// Nothing changed — skip the API write to avoid triggering a watch-event reconcile loop
-		if ready {
-			return ctrl.Result{RequeueAfter: GetSyncPeriod()}, nil
-		}
-		return ctrl.Result{RequeueAfter: ErrorRequeueDelay}, nil
-	}
-
 	realm.Status.Ready = ready
 	realm.Status.Status = status
 	realm.Status.Message = message
 	realm.Status.Instance = instanceRef
 
-	condition := metav1.Condition{
-		Type:               "Ready",
-		Status:             desiredConditionStatus,
-		Reason:             status,
-		Message:            message,
-		LastTransitionTime: metav1.Now(),
-	}
+	realm.Status.Conditions = setReadyCondition(realm.Status.Conditions, ready, status, message)
 
-	found := false
-	for i, c := range realm.Status.Conditions {
-		if c.Type == "Ready" {
-			// Preserve LastTransitionTime if status did not flip
-			if c.Status == desiredConditionStatus {
-				condition.LastTransitionTime = c.LastTransitionTime
-			}
-			realm.Status.Conditions[i] = condition
-			found = true
-			break
-		}
-	}
-	if !found {
-		realm.Status.Conditions = append(realm.Status.Conditions, condition)
-	}
-
-	if err := r.Status().Update(ctx, realm); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	if ready {
-		return ctrl.Result{RequeueAfter: GetSyncPeriod()}, nil
-	}
-	return ctrl.Result{RequeueAfter: ErrorRequeueDelay}, nil
+	return writeStatusIfChanged(ctx, r.Client, realm, ready)
 }
 
 func (r *KeycloakRealmReconciler) resolveSmtpSecret(ctx context.Context, realm *keycloakv1beta1.KeycloakRealm) (string, string, error) {

--- a/internal/controller/keycloakrequiredaction_controller.go
+++ b/internal/controller/keycloakrequiredaction_controller.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -131,13 +130,24 @@ func (r *KeycloakRequiredActionReconciler) Reconcile(ctx context.Context, req ct
 		}
 		log.Info("required action registered and configured", "alias", alias)
 	} else {
-		// Required action exists -- update it
-		log.Info("updating required action", "alias", alias, "realm", realmName)
-		if err := kc.UpdateRequiredAction(ctx, realmName, alias, definition); err != nil {
-			RecordError(controllerName, "keycloak_api_error")
-			return r.updateStatus(ctx, ra, false, "UpdateFailed", fmt.Sprintf("Failed to update required action: %v", err), alias)
+		// Required action exists -- update it only when it actually drifted.
+		// Every PUT produces a Keycloak admin event, so an unconditional write
+		// floods admin_event_entity for actions that never change.
+		needsUpdate := true
+		if currentRaw, fetchErr := kc.GetRequiredActionRaw(ctx, realmName, alias); fetchErr == nil {
+			needsUpdate = !definitionsMatch(definition, currentRaw)
 		}
-		log.Info("required action updated", "alias", alias)
+
+		if needsUpdate {
+			log.Info("updating required action", "alias", alias, "realm", realmName)
+			if err := kc.UpdateRequiredAction(ctx, realmName, alias, definition); err != nil {
+				RecordError(controllerName, "keycloak_api_error")
+				return r.updateStatus(ctx, ra, false, "UpdateFailed", fmt.Sprintf("Failed to update required action: %v", err), alias)
+			}
+			log.Info("required action updated", "alias", alias)
+		} else {
+			log.V(1).Info("required action already in sync, skipping update", "alias", alias, "realm", realmName)
+		}
 	}
 
 	ra.Status.ResourcePath = fmt.Sprintf("/admin/realms/%s/authentication/required-actions/%s", realmName, alias)
@@ -267,37 +277,9 @@ func (r *KeycloakRequiredActionReconciler) updateStatus(ctx context.Context, ra 
 		ra.Status.ObservedGeneration = ra.Generation
 	}
 
-	condition := metav1.Condition{
-		Type:               "Ready",
-		Status:             metav1.ConditionFalse,
-		Reason:             status,
-		Message:            message,
-		LastTransitionTime: metav1.Now(),
-	}
-	if ready {
-		condition.Status = metav1.ConditionTrue
-	}
+	ra.Status.Conditions = setReadyCondition(ra.Status.Conditions, ready, status, message)
 
-	found := false
-	for i, c := range ra.Status.Conditions {
-		if c.Type == "Ready" {
-			ra.Status.Conditions[i] = condition
-			found = true
-			break
-		}
-	}
-	if !found {
-		ra.Status.Conditions = append(ra.Status.Conditions, condition)
-	}
-
-	if err := r.Status().Update(ctx, ra); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	if ready {
-		return ctrl.Result{RequeueAfter: GetSyncPeriod()}, nil
-	}
-	return ctrl.Result{RequeueAfter: ErrorRequeueDelay}, nil
+	return writeStatusIfChanged(ctx, r.Client, ra, ready)
 }
 
 // SetupWithManager sets up the controller with the Manager

--- a/internal/controller/keycloakrole_controller.go
+++ b/internal/controller/keycloakrole_controller.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -458,38 +457,9 @@ func (r *KeycloakRoleReconciler) updateStatus(ctx context.Context, role *keycloa
 		role.Status.ObservedGeneration = role.Generation
 	}
 
-	// Update conditions
-	condition := metav1.Condition{
-		Type:               "Ready",
-		Status:             metav1.ConditionFalse,
-		Reason:             status,
-		Message:            message,
-		LastTransitionTime: metav1.Now(),
-	}
-	if ready {
-		condition.Status = metav1.ConditionTrue
-	}
+	role.Status.Conditions = setReadyCondition(role.Status.Conditions, ready, status, message)
 
-	found := false
-	for i, c := range role.Status.Conditions {
-		if c.Type == "Ready" {
-			role.Status.Conditions[i] = condition
-			found = true
-			break
-		}
-	}
-	if !found {
-		role.Status.Conditions = append(role.Status.Conditions, condition)
-	}
-
-	if err := r.Status().Update(ctx, role); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	if ready {
-		return ctrl.Result{RequeueAfter: GetSyncPeriod()}, nil
-	}
-	return ctrl.Result{RequeueAfter: ErrorRequeueDelay}, nil
+	return writeStatusIfChanged(ctx, r.Client, role, ready)
 }
 
 // SetupWithManager sets up the controller with the Manager

--- a/internal/controller/keycloakrolemapping_controller.go
+++ b/internal/controller/keycloakrolemapping_controller.go
@@ -495,24 +495,6 @@ func (r *KeycloakRoleMappingReconciler) removeRoleMapping(ctx context.Context, m
 }
 
 func (r *KeycloakRoleMappingReconciler) updateStatus(ctx context.Context, mapping *keycloakv1beta1.KeycloakRoleMapping, ready bool, status, message, subjectType, subjectID, roleName, roleType string) (ctrl.Result, error) {
-	// Check if status actually changed
-	statusChanged := mapping.Status.Ready != ready ||
-		mapping.Status.Status != status ||
-		mapping.Status.Message != message ||
-		mapping.Status.SubjectType != subjectType ||
-		mapping.Status.SubjectID != subjectID ||
-		mapping.Status.RoleName != roleName ||
-		mapping.Status.RoleType != roleType
-
-	generationChanged := ready && mapping.Status.ObservedGeneration != mapping.Generation
-
-	if !statusChanged && !generationChanged {
-		if ready {
-			return ctrl.Result{RequeueAfter: GetSyncPeriod()}, nil
-		}
-		return ctrl.Result{RequeueAfter: ErrorRequeueDelay}, nil
-	}
-
 	mapping.Status.Ready = ready
 	mapping.Status.Status = status
 	mapping.Status.Message = message
@@ -527,15 +509,7 @@ func (r *KeycloakRoleMappingReconciler) updateStatus(ctx context.Context, mappin
 
 	mapping.Status.Conditions = setReadyCondition(mapping.Status.Conditions, ready, status, message)
 
-	if err := r.Status().Update(ctx, mapping); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	if !ready {
-		return ctrl.Result{RequeueAfter: ErrorRequeueDelay}, nil
-	}
-
-	return ctrl.Result{RequeueAfter: GetSyncPeriod()}, nil
+	return writeStatusIfChanged(ctx, r.Client, mapping, ready)
 }
 
 func (r *KeycloakRoleMappingReconciler) getKeycloakClientFromClusterRealm(ctx context.Context, clusterRealmName string) (*keycloak.Client, string, error) {

--- a/internal/controller/keycloakuser_controller.go
+++ b/internal/controller/keycloakuser_controller.go
@@ -9,7 +9,6 @@ import (
 	stderrors "errors"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -780,37 +779,6 @@ func (r *KeycloakUserReconciler) getKeycloakClientAndRealmFromClient(ctx context
 }
 
 func (r *KeycloakUserReconciler) updateStatus(ctx context.Context, user *keycloakv1beta1.KeycloakUser, ready bool, status, message, userID string, isServiceAccount bool, clientID string) (ctrl.Result, error) {
-	// Determine desired condition status
-	desiredConditionStatus := metav1.ConditionFalse
-	if ready {
-		desiredConditionStatus = metav1.ConditionTrue
-	}
-
-	// Check if status actually changed
-	statusChanged := user.Status.Ready != ready ||
-		user.Status.Status != status ||
-		user.Status.Message != message ||
-		user.Status.IsServiceAccount != isServiceAccount ||
-		user.Status.ClientID != clientID ||
-		(userID != "" && user.Status.UserID != userID)
-
-	conditionChanged := true
-	for _, c := range user.Status.Conditions {
-		if c.Type == "Ready" && c.Status == desiredConditionStatus && c.Reason == status && c.Message == message {
-			conditionChanged = false
-			break
-		}
-	}
-
-	generationChanged := ready && user.Status.ObservedGeneration != user.Generation
-
-	if !statusChanged && !conditionChanged && !generationChanged {
-		if ready {
-			return ctrl.Result{RequeueAfter: GetSyncPeriod()}, nil
-		}
-		return ctrl.Result{RequeueAfter: ErrorRequeueDelay}, nil
-	}
-
 	user.Status.Ready = ready
 	user.Status.Status = status
 	user.Status.Message = message
@@ -824,37 +792,9 @@ func (r *KeycloakUserReconciler) updateStatus(ctx context.Context, user *keycloa
 		user.Status.ObservedGeneration = user.Generation
 	}
 
-	condition := metav1.Condition{
-		Type:               "Ready",
-		Status:             desiredConditionStatus,
-		Reason:             status,
-		Message:            message,
-		LastTransitionTime: metav1.Now(),
-	}
+	user.Status.Conditions = setReadyCondition(user.Status.Conditions, ready, status, message)
 
-	found := false
-	for i, c := range user.Status.Conditions {
-		if c.Type == "Ready" {
-			if c.Status == desiredConditionStatus {
-				condition.LastTransitionTime = c.LastTransitionTime
-			}
-			user.Status.Conditions[i] = condition
-			found = true
-			break
-		}
-	}
-	if !found {
-		user.Status.Conditions = append(user.Status.Conditions, condition)
-	}
-
-	if err := r.Status().Update(ctx, user); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	if ready {
-		return ctrl.Result{RequeueAfter: GetSyncPeriod()}, nil
-	}
-	return ctrl.Result{RequeueAfter: ErrorRequeueDelay}, nil
+	return writeStatusIfChanged(ctx, r.Client, user, ready)
 }
 
 // SetupWithManager sets up the controller with the Manager

--- a/internal/controller/keycloakusercredential_controller.go
+++ b/internal/controller/keycloakusercredential_controller.go
@@ -391,16 +391,7 @@ func (r *KeycloakUserCredentialReconciler) updateStatus(ctx context.Context, cre
 
 	cred.Status.Conditions = setReadyCondition(cred.Status.Conditions, ready, status, message)
 
-	if err := r.Status().Update(ctx, cred); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	if !ready {
-		return ctrl.Result{RequeueAfter: ErrorRequeueDelay}, nil
-	}
-
-	// Requeue after 5 minutes for periodic sync check
-	return ctrl.Result{RequeueAfter: GetSyncPeriod()}, nil
+	return writeStatusIfChanged(ctx, r.Client, cred, ready)
 }
 
 // hashPassword creates a SHA256 hash of the password for change detection

--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -1,0 +1,102 @@
+package controller
+
+import (
+	"context"
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const ReadyConditionType = "Ready"
+
+// setReadyCondition adds or updates the "Ready" condition in the supplied slice,
+// preserving LastTransitionTime while the condition status does not flip.
+//
+// The timestamp must not be refreshed on every pass: a status write that only
+// moves LastTransitionTime still bumps resourceVersion, which fires the
+// controller's own watch and re-enqueues the object immediately instead of
+// honouring the sync period.
+func setReadyCondition(conditions []metav1.Condition, ready bool, reason, message string) []metav1.Condition {
+	status := metav1.ConditionFalse
+	if ready {
+		status = metav1.ConditionTrue
+	}
+
+	condition := metav1.Condition{
+		Type:               ReadyConditionType,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		LastTransitionTime: metav1.Now(),
+	}
+
+	for i, c := range conditions {
+		if c.Type == ReadyConditionType {
+			if c.Status == status {
+				condition.LastTransitionTime = c.LastTransitionTime
+			}
+			conditions[i] = condition
+			return conditions
+		}
+	}
+	return append(conditions, condition)
+}
+
+// writeStatusIfChanged persists obj's status only when it differs from what the
+// API server already holds, then returns the requeue result for the reconcile
+// outcome.
+//
+// Skipping no-op writes is what keeps a steady-state resource quiescent; see
+// setReadyCondition for why an unconditional write self-triggers.
+func writeStatusIfChanged(ctx context.Context, c client.Client, obj client.Object, ready bool) (ctrl.Result, error) {
+	if !statusMatchesStored(ctx, c, obj) {
+		if err := c.Status().Update(ctx, obj); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	if ready {
+		return ctrl.Result{RequeueAfter: GetSyncPeriod()}, nil
+	}
+	return ctrl.Result{RequeueAfter: ErrorRequeueDelay}, nil
+}
+
+// statusMatchesStored reports whether obj's in-memory status already equals the
+// stored one. The comparison reads through the informer cache rather than
+// snapshotting at the top of updateStatus, because reconcilers routinely set
+// status fields (ResourcePath, PasswordHash, …) before calling it — a snapshot
+// taken here would classify those as already persisted and silently drop them.
+//
+// Anything unexpected (read error, no Status field) is reported as a mismatch
+// so the write still goes ahead.
+func statusMatchesStored(ctx context.Context, c client.Client, obj client.Object) bool {
+	stored, ok := obj.DeepCopyObject().(client.Object)
+	if !ok {
+		return false
+	}
+	if err := c.Get(ctx, client.ObjectKeyFromObject(obj), stored); err != nil {
+		return false
+	}
+
+	storedStatus, currentStatus := statusOf(stored), statusOf(obj)
+	if storedStatus == nil || currentStatus == nil {
+		return false
+	}
+	return equality.Semantic.DeepEqual(storedStatus, currentStatus)
+}
+
+// statusOf returns the Status field of a Keycloak CR, or nil if the type has none.
+func statusOf(obj client.Object) interface{} {
+	v := reflect.ValueOf(obj)
+	if v.Kind() != reflect.Ptr || v.IsNil() {
+		return nil
+	}
+	field := v.Elem().FieldByName("Status")
+	if !field.IsValid() {
+		return nil
+	}
+	return field.Interface()
+}

--- a/internal/controller/status_test.go
+++ b/internal/controller/status_test.go
@@ -1,0 +1,137 @@
+package controller
+
+import (
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSetReadyCondition(t *testing.T) {
+	t.Run("appends Ready condition when none exists", func(t *testing.T) {
+		out := setReadyCondition(nil, true, "Ready", "all good")
+		if len(out) != 1 {
+			t.Fatalf("expected 1 condition, got %d", len(out))
+		}
+		if out[0].Type != ReadyConditionType {
+			t.Errorf("expected condition type %q, got %q", ReadyConditionType, out[0].Type)
+		}
+		if out[0].Status != metav1.ConditionTrue {
+			t.Errorf("expected ConditionTrue, got %q", out[0].Status)
+		}
+		if out[0].Reason != "Ready" {
+			t.Errorf("expected reason %q, got %q", "Ready", out[0].Reason)
+		}
+		if out[0].Message != "all good" {
+			t.Errorf("expected message %q, got %q", "all good", out[0].Message)
+		}
+		if out[0].LastTransitionTime.IsZero() {
+			t.Error("expected LastTransitionTime to be set")
+		}
+	})
+
+	t.Run("sets ConditionFalse when not ready", func(t *testing.T) {
+		out := setReadyCondition(nil, false, "InvalidSpec", "missing field")
+		if out[0].Status != metav1.ConditionFalse {
+			t.Errorf("expected ConditionFalse, got %q", out[0].Status)
+		}
+		if out[0].Reason != "InvalidSpec" {
+			t.Errorf("expected reason %q, got %q", "InvalidSpec", out[0].Reason)
+		}
+	})
+
+	t.Run("replaces existing Ready condition in place", func(t *testing.T) {
+		existing := []metav1.Condition{
+			{Type: ReadyConditionType, Status: metav1.ConditionFalse, Reason: "Pending", Message: "old"},
+			{Type: "OtherCondition", Status: metav1.ConditionTrue, Reason: "X", Message: "untouched"},
+		}
+		out := setReadyCondition(existing, true, "Ready", "now ok")
+		if len(out) != 2 {
+			t.Fatalf("expected 2 conditions, got %d", len(out))
+		}
+		if out[0].Status != metav1.ConditionTrue || out[0].Reason != "Ready" || out[0].Message != "now ok" {
+			t.Errorf("Ready condition was not updated correctly: %+v", out[0])
+		}
+		if out[1].Type != "OtherCondition" || out[1].Reason != "X" || out[1].Message != "untouched" {
+			t.Errorf("non-Ready condition should be left alone, got %+v", out[1])
+		}
+	})
+
+	t.Run("preserves order when Ready is not first", func(t *testing.T) {
+		existing := []metav1.Condition{
+			{Type: "OtherCondition", Status: metav1.ConditionTrue, Reason: "X", Message: "untouched"},
+			{Type: ReadyConditionType, Status: metav1.ConditionFalse, Reason: "Pending", Message: "old"},
+		}
+		out := setReadyCondition(existing, true, "Ready", "ok")
+		if len(out) != 2 {
+			t.Fatalf("expected 2 conditions, got %d", len(out))
+		}
+		if out[0].Type != "OtherCondition" {
+			t.Errorf("expected first condition to remain OtherCondition, got %q", out[0].Type)
+		}
+		if out[1].Type != ReadyConditionType || out[1].Status != metav1.ConditionTrue {
+			t.Errorf("expected Ready condition at index 1 to be true, got %+v", out[1])
+		}
+	})
+
+	// Regression guard for issue #121: refreshing LastTransitionTime on an
+	// unchanged condition makes every reconcile rewrite status, which
+	// re-triggers the controller's own watch and produces a hot loop.
+	t.Run("preserves LastTransitionTime when the status does not flip", func(t *testing.T) {
+		original := metav1.NewTime(time.Now().Add(-time.Hour).Truncate(time.Second))
+		existing := []metav1.Condition{{
+			Type:               ReadyConditionType,
+			Status:             metav1.ConditionTrue,
+			Reason:             "Ready",
+			Message:            "synchronized",
+			LastTransitionTime: original,
+		}}
+
+		out := setReadyCondition(existing, true, "Ready", "synchronized")
+
+		if !out[0].LastTransitionTime.Equal(&original) {
+			t.Errorf("LastTransitionTime changed on a no-op update: got %v, want %v",
+				out[0].LastTransitionTime, original)
+		}
+	})
+
+	t.Run("updates reason and message without moving LastTransitionTime", func(t *testing.T) {
+		original := metav1.NewTime(time.Now().Add(-time.Hour).Truncate(time.Second))
+		existing := []metav1.Condition{{
+			Type:               ReadyConditionType,
+			Status:             metav1.ConditionTrue,
+			Reason:             "Ready",
+			Message:            "old message",
+			LastTransitionTime: original,
+		}}
+
+		out := setReadyCondition(existing, true, "Ready", "new message")
+
+		if out[0].Message != "new message" {
+			t.Errorf("expected message to be updated, got %q", out[0].Message)
+		}
+		if !out[0].LastTransitionTime.Equal(&original) {
+			t.Error("LastTransitionTime must not move when only the message changes")
+		}
+	})
+
+	t.Run("moves LastTransitionTime when the status flips", func(t *testing.T) {
+		original := metav1.NewTime(time.Now().Add(-time.Hour).Truncate(time.Second))
+		existing := []metav1.Condition{{
+			Type:               ReadyConditionType,
+			Status:             metav1.ConditionTrue,
+			Reason:             "Ready",
+			Message:            "synchronized",
+			LastTransitionTime: original,
+		}}
+
+		out := setReadyCondition(existing, false, "SyncFailed", "boom")
+
+		if out[0].Status != metav1.ConditionFalse {
+			t.Errorf("expected status False, got %q", out[0].Status)
+		}
+		if out[0].LastTransitionTime.Equal(&original) {
+			t.Error("LastTransitionTime must advance when the condition status flips")
+		}
+	})
+}

--- a/internal/keycloak/client.go
+++ b/internal/keycloak/client.go
@@ -1625,6 +1625,11 @@ func (c *Client) GetRequiredAction(ctx context.Context, realmName, alias string)
 	return &action, nil
 }
 
+// GetRequiredActionRaw gets a required action by alias as raw JSON
+func (c *Client) GetRequiredActionRaw(ctx context.Context, realmName, alias string) (json.RawMessage, error) {
+	return c.GetRaw(ctx, "/admin/realms/"+url.PathEscape(realmName)+"/authentication/required-actions/"+url.PathEscape(alias))
+}
+
 // UpdateRequiredAction updates a required action
 func (c *Client) UpdateRequiredAction(ctx context.Context, realmName, alias string, action json.RawMessage) error {
 	cfg := DefaultRetryConfig()

--- a/test/e2e/drift_skip_test.go
+++ b/test/e2e/drift_skip_test.go
@@ -233,6 +233,47 @@ func TestDriftSkip(t *testing.T) {
 		require.True(t, final.Status.Ready, "realm should remain Ready after skipped reconcile")
 	})
 
+	t.Run("KeycloakRequiredAction_InSyncSkipsUpdate", func(t *testing.T) {
+		realmName := createTestRealm(t, instanceName, "drift-reqaction")
+
+		raName := fmt.Sprintf("drift-reqaction-%d", time.Now().UnixNano())
+		ra := &keycloakv1beta1.KeycloakRequiredAction{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      raName,
+				Namespace: testNamespace,
+			},
+			Spec: keycloakv1beta1.KeycloakRequiredActionSpec{
+				RealmRef: &keycloakv1beta1.ResourceRef{Name: realmName},
+				Alias:    strPtr("UPDATE_PASSWORD"),
+				Definition: rawJSON(`{
+					"name": "Update Password",
+					"providerId": "UPDATE_PASSWORD",
+					"enabled": true,
+					"defaultAction": true,
+					"priority": 20
+				}`),
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, ra))
+		t.Cleanup(func() { k8sClient.Delete(ctx, ra) })
+
+		waitForRequiredActionReady(t, ra.Name, ra.Namespace)
+
+		// Without drift detection the controller PUTs on every pass, and each
+		// PUT produces a Keycloak admin event — the flood reported in #121.
+		updated := &keycloakv1beta1.KeycloakRequiredAction{}
+		require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: ra.Name, Namespace: ra.Namespace}, updated))
+
+		since := time.Now().UTC()
+		bumpReconcile(t, updated)
+
+		assertSkipLogged(t, since, "required action already in sync, skipping update", "alias", "UPDATE_PASSWORD")
+
+		final := &keycloakv1beta1.KeycloakRequiredAction{}
+		require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: ra.Name, Namespace: ra.Namespace}, final))
+		require.True(t, final.Status.Ready, "required action should remain Ready after skipped reconcile")
+	})
+
 	t.Run("KeycloakOrganization_DomainsVerifiedNoLoop", func(t *testing.T) {
 		// Organizations require Keycloak 26+; skip on older instances.
 		instance := &keycloakv1beta1.KeycloakInstance{}
@@ -422,6 +463,19 @@ func waitForRealmReady(t *testing.T, name, namespace string) {
 		return updated.Status.Ready, nil
 	})
 	require.NoError(t, err, "KeycloakRealm %s/%s did not become ready", namespace, name)
+}
+
+// waitForRequiredActionReady waits for a KeycloakRequiredAction to reach Ready status.
+func waitForRequiredActionReady(t *testing.T, name, namespace string) {
+	t.Helper()
+	err := wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+		updated := &keycloakv1beta1.KeycloakRequiredAction{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, updated); err != nil {
+			return false, nil
+		}
+		return updated.Status.Ready, nil
+	})
+	require.NoError(t, err, "KeycloakRequiredAction %s/%s did not become ready", namespace, name)
 }
 
 // waitForOrganizationReady waits for a KeycloakOrganization to reach Ready status.

--- a/test/e2e/reconcile_loop_test.go
+++ b/test/e2e/reconcile_loop_test.go
@@ -1,0 +1,217 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	keycloakv1beta1 "github.com/Hostzero-GmbH/keycloak-operator/api/v1beta1"
+)
+
+// TestNoSteadyStateStatusChurn asserts that reconciling an already-Ready,
+// unchanged resource does not rewrite its status.
+//
+// A status write bumps resourceVersion, which fires the controller's own
+// For() watch and re-enqueues the object immediately instead of honouring
+// the sync period. The historical trigger was `LastTransitionTime:
+// metav1.Now()` being refreshed on every pass: because metav1.Time has
+// second granularity the loop only self-sustains when a reconcile crosses a
+// second boundary, so asserting on loop *rate* is inherently flaky on a fast
+// cluster. These sub-tests assert the underlying invariant instead — a no-op
+// reconcile must leave lastTransitionTime and resourceVersion untouched.
+func TestNoSteadyStateStatusChurn(t *testing.T) {
+	skipIfNoCluster(t)
+
+	instanceName, _ := getOrCreateInstance(t)
+	realmName := createTestRealm(t, instanceName, "noloop")
+
+	// Covers the controller reported in #121 plus representatives of the
+	// other status-write shapes: a plain namespaced child (group), one that
+	// tracks ObservedGeneration (role), and one whose identity lives in a
+	// sub-resource path (clientscope).
+	cases := []struct {
+		name string
+		gvk  schema.GroupVersionKind
+		make func(t *testing.T, name string) client.Object
+	}{
+		{
+			name: "KeycloakRequiredAction",
+			gvk:  keycloakv1beta1.GroupVersion.WithKind("KeycloakRequiredAction"),
+			make: func(t *testing.T, name string) client.Object {
+				return &keycloakv1beta1.KeycloakRequiredAction{
+					ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
+					Spec: keycloakv1beta1.KeycloakRequiredActionSpec{
+						RealmRef: &keycloakv1beta1.ResourceRef{Name: realmName},
+						Alias:    strPtr("UPDATE_PASSWORD"),
+						Definition: rawJSON(`{
+							"name": "Update Password",
+							"providerId": "UPDATE_PASSWORD",
+							"enabled": true,
+							"defaultAction": true,
+							"priority": 20
+						}`),
+					},
+				}
+			},
+		},
+		{
+			name: "KeycloakGroup",
+			gvk:  keycloakv1beta1.GroupVersion.WithKind("KeycloakGroup"),
+			make: func(t *testing.T, name string) client.Object {
+				return &keycloakv1beta1.KeycloakGroup{
+					ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
+					Spec: keycloakv1beta1.KeycloakGroupSpec{
+						RealmRef:   &keycloakv1beta1.ResourceRef{Name: realmName},
+						Name:       strPtr(name),
+						Definition: rawJSON(`{}`),
+					},
+				}
+			},
+		},
+		{
+			name: "KeycloakRole",
+			gvk:  keycloakv1beta1.GroupVersion.WithKind("KeycloakRole"),
+			make: func(t *testing.T, name string) client.Object {
+				return &keycloakv1beta1.KeycloakRole{
+					ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
+					Spec: keycloakv1beta1.KeycloakRoleSpec{
+						RealmRef:   &keycloakv1beta1.ResourceRef{Name: realmName},
+						Name:       strPtr(name),
+						Definition: rawJSON(`{"description": "noloop role"}`),
+					},
+				}
+			},
+		},
+		{
+			name: "KeycloakClientScope",
+			gvk:  keycloakv1beta1.GroupVersion.WithKind("KeycloakClientScope"),
+			make: func(t *testing.T, name string) client.Object {
+				return &keycloakv1beta1.KeycloakClientScope{
+					ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
+					Spec: keycloakv1beta1.KeycloakClientScopeSpec{
+						RealmRef: &keycloakv1beta1.ResourceRef{Name: realmName},
+						Name:     strPtr(name),
+						Definition: rawJSON(`{
+							"protocol": "openid-connect",
+							"description": "noloop scope"
+						}`),
+					},
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			name := fmt.Sprintf("noloop-%s-%d", shortKind(tc.gvk.Kind), time.Now().UnixNano())
+			obj := tc.make(t, name)
+
+			require.NoError(t, k8sClient.Create(ctx, obj))
+			t.Cleanup(func() { k8sClient.Delete(ctx, obj) })
+
+			key := types.NamespacedName{Name: name, Namespace: testNamespace}
+			waitForUnstructuredReady(t, tc.gvk, key)
+
+			// Let any create-time follow-up writes settle so the baseline is
+			// a genuinely quiescent object.
+			time.Sleep(3 * time.Second)
+
+			before := getUnstructured(t, tc.gvk, key)
+			ltBefore := readyLastTransitionTime(t, before)
+			rvBefore := before.GetResourceVersion()
+
+			// Sleep past a second boundary: with the LastTransitionTime bug
+			// the next reconcile necessarily computes a different timestamp,
+			// which is what makes this deterministic rather than racy.
+			time.Sleep(2 * time.Second)
+
+			// Force exactly one reconcile. Nothing about the desired state
+			// changed, so the controller must not write status at all.
+			bumpReconcile(t, before.DeepCopy())
+
+			after := getUnstructured(t, tc.gvk, key)
+			ltAfter := readyLastTransitionTime(t, after)
+
+			require.Equal(t, ltBefore, ltAfter,
+				"Ready condition lastTransitionTime changed on a no-op reconcile; "+
+					"status is being rewritten every pass, which re-triggers the controller's "+
+					"own watch and causes a reconcile hot loop (issue #121)")
+
+			// resourceVersion may legitimately have advanced once for the
+			// annotation patch itself, but must then stop moving. A sustained
+			// loop keeps bumping it.
+			rvSettled := getUnstructured(t, tc.gvk, key).GetResourceVersion()
+			time.Sleep(15 * time.Second)
+			rvLater := getUnstructured(t, tc.gvk, key).GetResourceVersion()
+
+			require.Equal(t, rvSettled, rvLater,
+				"resourceVersion advanced from %s to %s while the resource was untouched "+
+					"(baseline before reconcile was %s); the controller is re-reconciling "+
+					"itself instead of honouring the sync period",
+				rvSettled, rvLater, rvBefore)
+		})
+	}
+}
+
+// shortKind trims the common Keycloak prefix and lowercases the result so
+// generated object names are valid RFC 1123 subdomains.
+func shortKind(kind string) string {
+	return strings.ToLower(strings.TrimPrefix(kind, "Keycloak"))
+}
+
+func getUnstructured(t *testing.T, gvk schema.GroupVersionKind, key types.NamespacedName) *unstructured.Unstructured {
+	t.Helper()
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(gvk)
+	require.NoError(t, k8sClient.Get(ctx, key, u))
+	return u
+}
+
+func waitForUnstructuredReady(t *testing.T, gvk schema.GroupVersionKind, key types.NamespacedName) {
+	t.Helper()
+	err := wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+		u := &unstructured.Unstructured{}
+		u.SetGroupVersionKind(gvk)
+		if err := k8sClient.Get(ctx, key, u); err != nil {
+			return false, nil
+		}
+		ready, found, err := unstructured.NestedBool(u.Object, "status", "ready")
+		if err != nil || !found {
+			return false, nil
+		}
+		return ready, nil
+	})
+	require.NoError(t, err, "%s %s did not become ready", gvk.Kind, key)
+}
+
+// readyLastTransitionTime extracts status.conditions[type=Ready].lastTransitionTime.
+func readyLastTransitionTime(t *testing.T, u *unstructured.Unstructured) string {
+	t.Helper()
+	conditions, found, err := unstructured.NestedSlice(u.Object, "status", "conditions")
+	require.NoError(t, err)
+	require.True(t, found, "no status.conditions on %s/%s", u.GetKind(), u.GetName())
+
+	for _, raw := range conditions {
+		c, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if c["type"] == "Ready" {
+			lt, _ := c["lastTransitionTime"].(string)
+			require.NotEmpty(t, lt, "Ready condition has no lastTransitionTime")
+			return lt
+		}
+	}
+	t.Fatalf("no Ready condition found on %s/%s", u.GetKind(), u.GetName())
+	return ""
+}


### PR DESCRIPTION
… writes

Every controller rebuilt the Ready condition with a fresh LastTransitionTime and wrote status unconditionally on each pass. The write bumps resourceVersion, fires the controller's own watch, and re-enqueues the object immediately instead of honouring the sync period — flooding Keycloak with admin events for resources that never change.

Replace the 18 hand-rolled updateStatus tails with shared helpers: setReadyCondition preserves LastTransitionTime unless the condition flips, and writeStatusIfChanged skips the write when status already matches the stored object (compared via a cache read, since reconcilers set status fields before reaching updateStatus).

Also gate the KeycloakRequiredAction PUT behind definitionsMatch so a steady-state action produces zero admin events instead of one per sync.

Fixes #121