### PR TITLE
fix: reject protocolMappers in definition, make KeycloakProtocolMapper the single home

### DIFF
--- a/docs/src/crds.md
+++ b/docs/src/crds.md
@@ -109,7 +109,7 @@ Fully typed CRDs without a `definition` (KeycloakInstance, KeycloakRoleMapping, 
 For contributors, the layer of a new field follows mechanically:
 
 - References a Kubernetes object or another CR? → typed spec field (layer 3).
-- Managed through a separate Keycloak API endpoint rather than the representation `PUT`? → its own CRD (like KeycloakRoleMapping) or a typed spec section — never keys inside `definition`.
+- Managed through a separate Keycloak API endpoint rather than the representation `PUT`? → its own CRD (like KeycloakRoleMapping or KeycloakProtocolMapper) or a typed spec section — never keys inside `definition`. Such a key is rejected with `Ready=False`, because Keycloak may accept the parent `PUT` while discarding the nested change.
 - Part of the Keycloak representation itself? → stays in `definition`, untyped.
 
 ### Status Tracking

--- a/docs/src/crds/keycloakclientscope.md
+++ b/docs/src/crds/keycloakclientscope.md
@@ -67,6 +67,11 @@ spec:
 
 ### Scope with Protocol Mappers
 
+Protocol mappers are declared as separate [KeycloakProtocolMapper](keycloakprotocolmapper.md)
+resources. Keycloak ignores `protocolMappers` sent on the client scope update
+endpoint, so the operator rejects the key inside `definition` rather than
+accepting edits it cannot apply.
+
 ```yaml
 apiVersion: keycloak.hostzero.com/v1beta1
 kind: KeycloakClientScope
@@ -79,18 +84,26 @@ spec:
   definition:
     description: Department information
     protocol: openid-connect
-    protocolMappers:
-      - name: department
-        protocol: openid-connect
-        protocolMapper: oidc-usermodel-attribute-mapper
-        consentRequired: false
-        config:
-          claim.name: department
-          user.attribute: department
-          jsonType.label: String
-          id.token.claim: "true"
-          access.token.claim: "true"
-          userinfo.token.claim: "true"
+---
+apiVersion: keycloak.hostzero.com/v1beta1
+kind: KeycloakProtocolMapper
+metadata:
+  name: department
+spec:
+  clientScopeRef:
+    name: department-scope
+  name: department
+  definition:
+    protocol: openid-connect
+    protocolMapper: oidc-usermodel-attribute-mapper
+    consentRequired: false
+    config:
+      claim.name: department
+      user.attribute: department
+      jsonType.label: String
+      id.token.claim: "true"
+      access.token.claim: "true"
+      userinfo.token.claim: "true"
 ```
 
 ## Definition Properties
@@ -100,8 +113,9 @@ spec:
 | `name` | string | Scope name (required) |
 | `description` | string | Description |
 | `protocol` | string | Protocol (openid-connect, saml) |
-| `protocolMappers` | array | Protocol mapper configurations |
 | `attributes` | map | Additional attributes |
+
+`protocolMappers` is rejected here; use [KeycloakProtocolMapper](keycloakprotocolmapper.md).
 
 ## Short Names
 

--- a/internal/controller/definition.go
+++ b/internal/controller/definition.go
@@ -1,0 +1,35 @@
+package controller
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// UnsupportedDefinitionFieldReason is the status/condition reason used when
+// spec.definition carries a key whose datum belongs to a dedicated CRD.
+const UnsupportedDefinitionFieldReason = "UnsupportedDefinitionField"
+
+// rejectDefinitionKey fails reconcile when spec.definition contains key.
+//
+// Keycloak manages some sub-resources only through their own endpoints and
+// silently ignores them on the parent representation PUT (client scope protocol
+// mappers return 204 while discarding the change). Such data has its own CRD, so
+// accepting it here would mean a second home for the same datum and, worse, edits
+// that appear to succeed but never reach Keycloak.
+func rejectDefinitionKey(definition []byte, key, ownerKind string) error {
+	if len(definition) == 0 {
+		return nil
+	}
+
+	// Malformed JSON is reported by the caller's own parse of the definition.
+	var defMap map[string]json.RawMessage
+	if err := json.Unmarshal(definition, &defMap); err != nil {
+		return nil
+	}
+
+	if _, present := defMap[key]; !present {
+		return nil
+	}
+
+	return fmt.Errorf("spec.definition.%s is not supported; declare each entry as a %s resource instead", key, ownerKind)
+}

--- a/internal/controller/definition_test.go
+++ b/internal/controller/definition_test.go
@@ -1,0 +1,60 @@
+package controller
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRejectDefinitionKey(t *testing.T) {
+	tests := []struct {
+		name       string
+		definition string
+		wantErr    bool
+	}{
+		{
+			name:       "absent key passes",
+			definition: `{"protocol": "openid-connect"}`,
+		},
+		{
+			name:       "empty definition passes",
+			definition: ``,
+		},
+		{
+			name:       "malformed definition defers to caller parse",
+			definition: `{not json`,
+		},
+		{
+			name:       "present key is rejected",
+			definition: `{"protocol": "openid-connect", "protocolMappers": [{"name": "m2m"}]}`,
+			wantErr:    true,
+		},
+		{
+			name:       "empty array still counts as present",
+			definition: `{"protocolMappers": []}`,
+			wantErr:    true,
+		},
+		{
+			name:       "null still counts as present",
+			definition: `{"protocolMappers": null}`,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := rejectDefinitionKey([]byte(tt.definition), "protocolMappers", "KeycloakProtocolMapper")
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got nil")
+				}
+				if !strings.Contains(err.Error(), "KeycloakProtocolMapper") {
+					t.Errorf("error should name the owning CRD, got %q", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("expected no error, got %v", err)
+			}
+		})
+	}
+}

--- a/internal/controller/keycloakclient_controller.go
+++ b/internal/controller/keycloakclient_controller.go
@@ -106,6 +106,16 @@ func (r *KeycloakClientReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 	}
 
+	// Protocol mappers have their own CRD. Keycloak does honour them on the client
+	// PUT, but allowing both homes would let a KeycloakProtocolMapper and this
+	// definition key fight over the same mapper.
+	if kcClient.Spec.Definition != nil {
+		if err := rejectDefinitionKey(kcClient.Spec.Definition.Raw, "protocolMappers", "KeycloakProtocolMapper"); err != nil {
+			RecordError(controllerName, "unsupported_definition_field")
+			return r.updateStatus(ctx, kcClient, false, UnsupportedDefinitionFieldReason, err.Error(), "", instanceRef, realmRef)
+		}
+	}
+
 	// Resolve the clientId from spec.clientId.
 	resolvedClientID, err := resolveIdentifier("clientId", kcClient.Spec.ClientId, clientDef.ClientID)
 	if err != nil {
@@ -690,11 +700,12 @@ func valuesMatch(desired, current interface{}) bool {
 		return true
 	}
 
-	// Arrays of objects (e.g. protocolMappers): match by "name" field, require same
-	// length so that extra objects in Keycloak (e.g. an orphaned protocolMapper that
-	// the CR no longer declares) are detected as drift and removed by the PUT.
-	// Within each matched object, fields are still subset-compared because Keycloak
-	// adds fields the CR omits (id, consentRequired, ...).
+	// Arrays of objects (e.g. authorizationSettings.resources): match by "name"
+	// field, require same length so that extra objects in Keycloak that the CR no
+	// longer declares are detected as drift and removed by the PUT. Within each
+	// matched object, fields are still subset-compared because Keycloak adds fields
+	// the CR omits (id, ...). Exact comparison would instead report perpetual drift
+	// and re-PUT on every reconcile.
 	desiredObjArr, dIsObjArr := toObjectSlice(desired)
 	currentObjArr, cIsObjArr := toObjectSlice(current)
 	if dIsObjArr && cIsObjArr {

--- a/internal/controller/keycloakclient_controller_test.go
+++ b/internal/controller/keycloakclient_controller_test.go
@@ -116,19 +116,19 @@ func TestDefinitionsMatch_AttributeValueDiff(t *testing.T) {
 	}
 }
 
-func TestDefinitionsMatch_ProtocolMappersSubset(t *testing.T) {
-	// CR defines protocolMappers without id/consentRequired, KC adds those fields
+func TestDefinitionsMatch_ObjectArraySubset(t *testing.T) {
+	// CR defines an object array without the fields Keycloak adds on read (id, ...)
 	desired := json.RawMessage(`{
 		"clientId": "app",
-		"protocolMappers": [{"name": "test-mapper", "protocol": "openid-connect", "protocolMapper": "oidc-usermodel-attribute-mapper", "config": {"claim.name": "test"}}]
+		"authorizationSettings": {"resources": [{"name": "res-a", "type": "urn:app:resources:default"}]}
 	}`)
 	current := json.RawMessage(`{
 		"clientId": "app",
-		"protocolMappers": [{"id": "abc-123", "name": "test-mapper", "protocol": "openid-connect", "protocolMapper": "oidc-usermodel-attribute-mapper", "consentRequired": false, "config": {"claim.name": "test"}}]
+		"authorizationSettings": {"resources": [{"id": "abc-123", "name": "res-a", "type": "urn:app:resources:default", "ownerManagedAccess": false}]}
 	}`)
 
 	if !definitionsMatch(desired, current) {
-		t.Error("expected match: CR protocolMapper is a subset of KC protocolMapper")
+		t.Error("expected match: CR object is a subset of the Keycloak object")
 	}
 }
 
@@ -167,42 +167,36 @@ func TestDefinitionsMatch_SkipsOptionalClientScopes(t *testing.T) {
 	}
 }
 
-func TestDefinitionsMatch_ProtocolMappersExtraInCurrent(t *testing.T) {
-	// Keycloak has an extra protocolMapper that the CR no longer declares.
+func TestDefinitionsMatch_ObjectArrayExtraInCurrent(t *testing.T) {
+	// Keycloak has an extra object that the CR no longer declares.
 	// definitionsMatch must report drift so the PUT removes it.
 	desired := json.RawMessage(`{
 		"clientId": "app",
-		"protocolMappers": [{"name": "keep", "protocol": "openid-connect"}]
+		"authorizationSettings": {"resources": [{"name": "keep"}]}
 	}`)
 	current := json.RawMessage(`{
 		"clientId": "app",
-		"protocolMappers": [
-			{"name": "keep", "protocol": "openid-connect"},
-			{"name": "orphan", "protocol": "openid-connect"}
-		]
+		"authorizationSettings": {"resources": [{"name": "keep"}, {"name": "orphan"}]}
 	}`)
 
 	if definitionsMatch(desired, current) {
-		t.Error("expected no match: orphan protocolMapper in current must surface as drift")
+		t.Error("expected no match: orphan object in current must surface as drift")
 	}
 }
 
-func TestDefinitionsMatch_ProtocolMappersExtraInDesired(t *testing.T) {
-	// CR adds a protocolMapper that Keycloak doesn't have yet — must surface as drift.
+func TestDefinitionsMatch_ObjectArrayExtraInDesired(t *testing.T) {
+	// CR adds an object that Keycloak doesn't have yet — must surface as drift.
 	desired := json.RawMessage(`{
 		"clientId": "app",
-		"protocolMappers": [
-			{"name": "existing", "protocol": "openid-connect"},
-			{"name": "new-one", "protocol": "openid-connect"}
-		]
+		"authorizationSettings": {"resources": [{"name": "existing"}, {"name": "new-one"}]}
 	}`)
 	current := json.RawMessage(`{
 		"clientId": "app",
-		"protocolMappers": [{"name": "existing", "protocol": "openid-connect"}]
+		"authorizationSettings": {"resources": [{"name": "existing"}]}
 	}`)
 
 	if definitionsMatch(desired, current) {
-		t.Error("expected no match: CR adds a protocolMapper that current lacks")
+		t.Error("expected no match: CR adds an object that current lacks")
 	}
 }
 

--- a/internal/controller/keycloakclientscope_controller.go
+++ b/internal/controller/keycloakclientscope_controller.go
@@ -95,6 +95,13 @@ func (r *KeycloakClientScopeReconciler) Reconcile(ctx context.Context, req ctrl.
 		return r.updateStatus(ctx, clientScope, false, "InvalidDefinition", fmt.Sprintf("Failed to parse client scope definition: %v", err), "")
 	}
 
+	// Keycloak's client scope PUT silently discards protocolMappers, so they are
+	// only ever managed through KeycloakProtocolMapper.
+	if err := rejectDefinitionKey(clientScope.Spec.Definition.Raw, "protocolMappers", "KeycloakProtocolMapper"); err != nil {
+		RecordError(controllerName, "unsupported_definition_field")
+		return r.updateStatus(ctx, clientScope, false, UnsupportedDefinitionFieldReason, err.Error(), "")
+	}
+
 	// Resolve the client scope name from spec.name.
 	scopeName, err := resolveIdentifier("name", clientScope.Spec.Name, scopeDef.Name)
 	if err != nil {

--- a/test/e2e/clientscope_test.go
+++ b/test/e2e/clientscope_test.go
@@ -68,23 +68,17 @@ func TestKeycloakClientScopeE2E(t *testing.T) {
 		t.Logf("Client scope resource path: %s", updated.Status.ResourcePath)
 	})
 
-	t.Run("ClientScopeWithProtocolMappers", func(t *testing.T) {
-		scopeName := fmt.Sprintf("scope-with-mappers-%d", time.Now().UnixNano())
+	t.Run("ProtocolMappersInDefinitionRejected", func(t *testing.T) {
+		scopeName := fmt.Sprintf("scope-inline-mappers-%d", time.Now().UnixNano())
 		scopeDef := rawJSON(`{
-			"description": "Scope with protocol mappers",
+			"description": "Scope with inline protocol mappers",
 			"protocol": "openid-connect",
 			"protocolMappers": [
 				{
 					"name": "department",
 					"protocol": "openid-connect",
 					"protocolMapper": "oidc-usermodel-attribute-mapper",
-					"config": {
-						"claim.name": "department",
-						"user.attribute": "department",
-						"jsonType.label": "String",
-						"id.token.claim": "true",
-						"access.token.claim": "true"
-					}
+					"config": {"claim.name": "department", "user.attribute": "department"}
 				}
 			]
 		}`)
@@ -105,18 +99,128 @@ func TestKeycloakClientScopeE2E(t *testing.T) {
 			k8sClient.Delete(ctx, clientScope)
 		})
 
+		// Keycloak silently discards mappers on the client scope PUT, so the
+		// operator refuses the inline form rather than accepting edits it cannot apply.
+		updated := &keycloakv1beta1.KeycloakClientScope{}
 		err := wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
-			updated := &keycloakv1beta1.KeycloakClientScope{}
 			if err := k8sClient.Get(ctx, types.NamespacedName{
 				Name:      clientScope.Name,
 				Namespace: clientScope.Namespace,
 			}, updated); err != nil {
 				return false, nil
 			}
-			return updated.Status.Ready, nil
+			return updated.Status.Status == "UnsupportedDefinitionField", nil
 		})
-		require.NoError(t, err, "Client scope with mappers did not become ready")
-		t.Logf("Client scope with protocol mappers %s is ready", scopeName)
+		require.NoError(t, err, "Client scope with inline mappers should be rejected")
+		require.False(t, updated.Status.Ready, "Scope must not be ready")
+		require.Contains(t, updated.Status.Message, "KeycloakProtocolMapper",
+			"message should point at the replacement CRD")
+	})
+
+	// Regression for #123: a mapper change must actually reach Keycloak. The inline
+	// definition form silently no-ops on update, so KeycloakProtocolMapper is the
+	// only supported path and has to survive an edit.
+	t.Run("ScopeProtocolMapperUpdates", func(t *testing.T) {
+		scopeName := fmt.Sprintf("scope-mapper-update-%d", time.Now().UnixNano())
+		clientScope := &keycloakv1beta1.KeycloakClientScope{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      scopeName,
+				Namespace: testNamespace,
+			},
+			Spec: keycloakv1beta1.KeycloakClientScopeSpec{
+				RealmRef:   &keycloakv1beta1.ResourceRef{Name: realmName},
+				Name:       strPtr(scopeName),
+				Definition: rawJSON(`{"protocol": "openid-connect"}`),
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, clientScope))
+		t.Cleanup(func() { k8sClient.Delete(ctx, clientScope) })
+
+		require.NoError(t, wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+			updated := &keycloakv1beta1.KeycloakClientScope{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: scopeName, Namespace: testNamespace}, updated); err != nil {
+				return false, nil
+			}
+			return updated.Status.Ready, nil
+		}), "Client scope did not become ready")
+
+		mapperName := fmt.Sprintf("m2m-%d", time.Now().UnixNano())
+		mapper := &keycloakv1beta1.KeycloakProtocolMapper{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      mapperName,
+				Namespace: testNamespace,
+			},
+			Spec: keycloakv1beta1.KeycloakProtocolMapperSpec{
+				ClientScopeRef: &keycloakv1beta1.ResourceRef{Name: scopeName},
+				Name:           strPtr(mapperName),
+				Definition: rawJSON(`{
+					"protocol": "openid-connect",
+					"protocolMapper": "oidc-hardcoded-claim-mapper",
+					"config": {
+						"claim.name": "is_m2m",
+						"claim.value": "true",
+						"id.token.claim": "true",
+						"access.token.claim": "true",
+						"jsonType.label": "boolean"
+					}
+				}`),
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, mapper))
+		t.Cleanup(func() { k8sClient.Delete(ctx, mapper) })
+
+		require.NoError(t, wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+			updated := &keycloakv1beta1.KeycloakProtocolMapper{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: mapperName, Namespace: testNamespace}, updated); err != nil {
+				return false, nil
+			}
+			return updated.Status.Ready, nil
+		}), "Protocol mapper did not become ready")
+
+		// Flip id.token.claim to false — the exact edit that was silently dropped.
+		current := &keycloakv1beta1.KeycloakProtocolMapper{}
+		require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: mapperName, Namespace: testNamespace}, current))
+		current.Spec.Definition = rawJSON(`{
+			"protocol": "openid-connect",
+			"protocolMapper": "oidc-hardcoded-claim-mapper",
+			"config": {
+				"claim.name": "is_m2m",
+				"claim.value": "true",
+				"id.token.claim": "false",
+				"access.token.claim": "true",
+				"jsonType.label": "boolean"
+			}
+		}`)
+		require.NoError(t, k8sClient.Update(ctx, current))
+
+		if !canConnectToKeycloak() {
+			t.Skip("no direct Keycloak connectivity; skipping mapper value assertion")
+		}
+
+		kc := getInternalKeycloakClient(t)
+		scopeID := ""
+		require.NoError(t, wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+			scopes, err := kc.GetClientScopes(ctx, realmName)
+			if err != nil {
+				return false, nil
+			}
+			for i := range scopes {
+				if scopes[i].Name != nil && *scopes[i].Name == scopeName {
+					scopeID = *scopes[i].ID
+					return true, nil
+				}
+			}
+			return false, nil
+		}), "client scope not found in Keycloak")
+
+		require.NoError(t, wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+			found, err := kc.GetClientScopeProtocolMapperByName(ctx, realmName, scopeID, mapperName)
+			if err != nil || found == nil {
+				return false, nil
+			}
+			return found.Config != nil && found.Config["id.token.claim"] == "false", nil
+		}), "mapper update never reached Keycloak")
+		t.Logf("mapper %q update applied in Keycloak", mapperName)
 	})
 
 	t.Run("ClientScopeCleanup", func(t *testing.T) {


### PR DESCRIPTION
## Description

Fixes #123.

Keycloak's `PUT /admin/realms/{realm}/client-scopes/{id}` accepts `protocolMappers` in the body, returns `204`, and **discards them**. Only the create `POST` imports them. So the first apply of a `KeycloakClientScope` with inline `definition.protocolMappers` works, and every later edit is a no-op that reports success. Upstream has closed this twice as intended behaviour (keycloak/keycloak#36065, keycloak/keycloak#45294), directing users to the dedicated protocol-mapper endpoints, so there is no upstream fix to wait for.

Clients are not affected by that limitation — Keycloak does sync mappers on the client `PUT` — which is why the same YAML behaves differently on the two CRDs today. That divergence is the worst outcome for users.

`KeycloakProtocolMapper` already supports `clientScopeRef` and already uses the correct sub-resource endpoints for both create and update, so the working path exists; the inline form was simply a second, broken home for the same datum.

## Approach

Reject `protocolMappers` inside `spec.definition` on **both** `KeycloakClientScope` and `KeycloakClient` with `Ready=False`, and make `KeycloakProtocolMapper` the single supported way.

This follows the `Spec Layout` decision guide in `docs/src/crds.md`, which already covers this exact case:

> Managed through a separate Keycloak API endpoint rather than the representation `PUT`? → its own CRD (like KeycloakRoleMapping) or a typed spec section — never keys inside `definition`.

Teaching the scope controller to reconcile `definition.protocolMappers` through the sub-resource endpoints was rejected as the alternative: it re-implements `KeycloakProtocolMapper` inside the scope controller, keeps two homes, and creates a genuine ownership conflict when a `KeycloakProtocolMapper` CR and a definition entry target the same mapper.

New shared guard `rejectDefinitionKey` in `internal/controller/definition.go`, deliberately mirroring the structure of `identifier.go` (small helper + reason constant, used uniformly).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Breaking change and migration

Manifests with `definition.protocolMappers` now go `Ready=False` with a message naming `KeycloakProtocolMapper`, so the required action is visible from `kubectl describe`.

**No mappers are destroyed.** Keycloak only syncs mappers when the field is present in the body, so omitting it leaves existing mappers in place. Affected resources stop reconciling; they do not lose configuration. Migration is mechanical — lift each entry into a `KeycloakProtocolMapper` with a `clientScopeRef`/`clientRef` and its `name` in `spec.name`.

For client scopes this is only nominally breaking, since updates never worked. For clients it is a real break, taken deliberately so one rule covers both.
