### PR TITLE
fix: address stale client role cleanup by UUID, not clientId

### DIFF
--- a/internal/controller/keycloakuser_controller.go
+++ b/internal/controller/keycloakuser_controller.go
@@ -542,23 +542,25 @@ func (r *KeycloakUserReconciler) reconcileUserClientRoles(ctx context.Context, k
 	// that are no longer in the wanted set (client key removed from spec).
 	// Use the composite /role-mappings endpoint to get ALL client role mappings
 	// in a single API call, avoiding the N+1 problem of iterating every realm client.
+	// The response is keyed by clientId, so the UUID the role-mapping endpoints
+	// expect has to come from the entry itself.
 	composite, compErr := kc.GetUserRoleMappingsComposite(ctx, realmName, userID)
 	if compErr != nil {
 		reconcileErrs = append(reconcileErrs, fmt.Errorf("stale cleanup composite: %w", compErr))
 	} else {
-		for clientUUID, entry := range composite.ClientMappings {
-			if wantedUUIDs[clientUUID] {
+		for clientID, entry := range composite.ClientMappings {
+			if wantedUUIDs[entry.ID] {
 				continue
 			}
 			if len(entry.Mappings) == 0 {
 				continue
 			}
-			if err := kc.DeleteClientRolesFromUser(ctx, realmName, clientUUID, userID, entry.Mappings); err != nil {
-				log.Error(err, "failed to clean up stale client roles", "clientUUID", clientUUID)
-				reconcileErrs = append(reconcileErrs, fmt.Errorf("stale cleanup for client %s: %w", clientUUID, err))
+			if err := kc.DeleteClientRolesFromUser(ctx, realmName, entry.ID, userID, entry.Mappings); err != nil {
+				log.Error(err, "failed to clean up stale client roles", "client", clientID, "clientUUID", entry.ID)
+				reconcileErrs = append(reconcileErrs, fmt.Errorf("stale cleanup for client %s: %w", clientID, err))
 				continue
 			}
-			log.V(1).Info("cleaned up stale client roles", "count", len(entry.Mappings), "client", entry.Client)
+			log.V(1).Info("cleaned up stale client roles", "count", len(entry.Mappings), "client", clientID)
 		}
 	}
 

--- a/internal/controller/keycloakuser_controller_test.go
+++ b/internal/controller/keycloakuser_controller_test.go
@@ -13,31 +13,38 @@ import (
 )
 
 // fakeUserKeycloak simulates Keycloak admin API for user role/group endpoints.
+// Maps keyed by client are keyed by client UUID, matching the real endpoints.
 type fakeUserKeycloak struct {
-	t            *testing.T
-	realmRoles   []keycloak.RoleRepresentation
-	userRealm    []keycloak.RoleRepresentation
-	clientRoles  map[string][]keycloak.RoleRepresentation
-	userClient   map[string][]keycloak.RoleRepresentation
-	groups       []keycloak.GroupRepresentation
-	userGroups   []keycloak.GroupRepresentation
-	addRealmCall int
-	delRealmCall int
-	addClient    map[string]int
-	delClient    map[string]int
-	addGroup     map[string]int
-	delGroup     map[string]int
+	t          *testing.T
+	realmRoles []keycloak.RoleRepresentation
+	userRealm  []keycloak.RoleRepresentation
+	// clientIDByUUID maps a client UUID to its clientId. Keycloak keys the
+	// composite role-mappings response by clientId while every other client
+	// endpoint addresses the UUID; keeping the two distinct is what makes
+	// confusing them observable in tests.
+	clientIDByUUID map[string]string
+	clientRoles    map[string][]keycloak.RoleRepresentation
+	userClient     map[string][]keycloak.RoleRepresentation
+	groups         []keycloak.GroupRepresentation
+	userGroups     []keycloak.GroupRepresentation
+	addRealmCall   int
+	delRealmCall   int
+	addClient      map[string]int
+	delClient      map[string]int
+	addGroup       map[string]int
+	delGroup       map[string]int
 }
 
 func newFakeUserKeycloak(t *testing.T) *fakeUserKeycloak {
 	return &fakeUserKeycloak{
-		t:           t,
-		clientRoles: make(map[string][]keycloak.RoleRepresentation),
-		userClient:  make(map[string][]keycloak.RoleRepresentation),
-		addClient:   make(map[string]int),
-		delClient:   make(map[string]int),
-		addGroup:    make(map[string]int),
-		delGroup:    make(map[string]int),
+		t:              t,
+		clientIDByUUID: map[string]string{"client-uuid-123": "my-app"},
+		clientRoles:    make(map[string][]keycloak.RoleRepresentation),
+		userClient:     make(map[string][]keycloak.RoleRepresentation),
+		addClient:      make(map[string]int),
+		delClient:      make(map[string]int),
+		addGroup:       make(map[string]int),
+		delGroup:       make(map[string]int),
 	}
 }
 
@@ -100,18 +107,23 @@ func (f *fakeUserKeycloak) handler() http.Handler {
 		http.Error(w, "not found", http.StatusNotFound)
 	})
 
-	// GET /admin/realms/{realm}/users/{id}/role-mappings — composite endpoint
+	// GET /admin/realms/{realm}/users/{id}/role-mappings — composite endpoint.
+	// Keyed by clientId, with the UUID carried in the entry's id field.
 	mux.HandleFunc("/admin/realms/test/users/user-123/role-mappings", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet {
-			// Return composite with clientMappings populated from userClient data
 			cm := make(map[string]keycloak.ClientRoleMappingsEntry)
 			for uuid, roles := range f.userClient {
-				if len(roles) > 0 {
-					cm[uuid] = keycloak.ClientRoleMappingsEntry{
-						ID:       uuid,
-						Client:   uuid,
-						Mappings: roles,
-					}
+				if len(roles) == 0 {
+					continue
+				}
+				clientID, ok := f.clientIDByUUID[uuid]
+				if !ok {
+					f.t.Fatalf("fake: client UUID %q has no registered clientId", uuid)
+				}
+				cm[clientID] = keycloak.ClientRoleMappingsEntry{
+					ID:       uuid,
+					Client:   clientID,
+					Mappings: roles,
 				}
 			}
 			writeUserJSON(w, keycloak.UserRoleMappingsComposite{
@@ -123,18 +135,23 @@ func (f *fakeUserKeycloak) handler() http.Handler {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 	})
 
-	// GET/POST/DELETE /admin/realms/{realm}/users/{id}/role-mappings/clients/{uuid}
-	mux.HandleFunc("/admin/realms/test/users/user-123/role-mappings/clients/client-uuid-123", func(w http.ResponseWriter, r *http.Request) {
+	// GET/POST/DELETE /admin/realms/{realm}/users/{id}/role-mappings/clients/{uuid}.
+	// Addressed by UUID; anything else is a 404 exactly as Keycloak answers.
+	const clientRoleMappings = "/admin/realms/test/users/user-123/role-mappings/clients/"
+	mux.HandleFunc(clientRoleMappings, func(w http.ResponseWriter, r *http.Request) {
+		uuid := r.URL.Path[len(clientRoleMappings):]
+		if _, known := f.clientIDByUUID[uuid]; !known {
+			http.Error(w, `{"error":"Client not found"}`, http.StatusNotFound)
+			return
+		}
 		switch r.Method {
 		case http.MethodGet:
-			writeUserJSON(w, f.userClient["client-uuid-123"])
+			writeUserJSON(w, f.userClient[uuid])
 		case http.MethodPost:
-			clientID := "client-uuid-123"
-			f.addClient[clientID]++
+			f.addClient[uuid]++
 			w.WriteHeader(http.StatusNoContent)
 		case http.MethodDelete:
-			clientID := "client-uuid-123"
-			f.delClient[clientID]++
+			f.delClient[uuid]++
 			w.WriteHeader(http.StatusNoContent)
 		default:
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -316,6 +333,73 @@ func TestReconcileUserClientRoles_Partial(t *testing.T) {
 	}
 	if fake.delClient["client-uuid-123"] != 1 {
 		t.Errorf("del client roles call count = %d, want 1", fake.delClient["client-uuid-123"])
+	}
+}
+
+// Regression for #124: the composite role-mappings response is keyed by clientId,
+// so a client the spec still wants must not be mistaken for a stale one and have
+// its roles deleted through a clientId-shaped path.
+func TestReconcileUserClientRoles_WantedClientIsNotStale(t *testing.T) {
+	fake := newFakeUserKeycloak(t)
+	fake.clientRoles["client-uuid-123"] = []keycloak.RoleRepresentation{
+		{ID: strPtr("cr-1"), Name: strPtr("manage-users")},
+	}
+	// User already holds exactly the wanted role, so nothing should change.
+	fake.userClient["client-uuid-123"] = []keycloak.RoleRepresentation{
+		{ID: strPtr("cr-1"), Name: strPtr("manage-users")},
+	}
+
+	srv := httptest.NewServer(fake.handler())
+	t.Cleanup(srv.Close)
+	kc := fake.client(srv.URL)
+
+	r := &KeycloakUserReconciler{}
+	err := r.reconcileUserClientRoles(context.Background(), kc, "test", "user-123", map[string][]string{
+		"my-app": {"manage-users"},
+	})
+	if err != nil {
+		t.Fatalf("reconcileUserClientRoles: %v", err)
+	}
+	if fake.delClient["client-uuid-123"] != 0 {
+		t.Errorf("wanted client must not be cleaned up, got %d delete calls", fake.delClient["client-uuid-123"])
+	}
+	if fake.addClient["client-uuid-123"] != 0 {
+		t.Errorf("no role changes expected, got %d add calls", fake.addClient["client-uuid-123"])
+	}
+}
+
+// Stale cleanup must address the client by UUID, so roles left on a client the
+// spec no longer mentions are actually removed.
+func TestReconcileUserClientRoles_StaleClientCleanedUp(t *testing.T) {
+	fake := newFakeUserKeycloak(t)
+	fake.clientIDByUUID["client-uuid-999"] = "legacy-app"
+	fake.clientRoles["client-uuid-123"] = []keycloak.RoleRepresentation{
+		{ID: strPtr("cr-1"), Name: strPtr("admin")},
+	}
+	fake.userClient["client-uuid-123"] = []keycloak.RoleRepresentation{
+		{ID: strPtr("cr-1"), Name: strPtr("admin")},
+	}
+	// Left over from a client key that was removed from spec.clientRoles.
+	fake.userClient["client-uuid-999"] = []keycloak.RoleRepresentation{
+		{ID: strPtr("old-1"), Name: strPtr("obsolete")},
+	}
+
+	srv := httptest.NewServer(fake.handler())
+	t.Cleanup(srv.Close)
+	kc := fake.client(srv.URL)
+
+	r := &KeycloakUserReconciler{}
+	err := r.reconcileUserClientRoles(context.Background(), kc, "test", "user-123", map[string][]string{
+		"my-app": {"admin"},
+	})
+	if err != nil {
+		t.Fatalf("reconcileUserClientRoles: %v", err)
+	}
+	if fake.delClient["client-uuid-999"] != 1 {
+		t.Errorf("stale client roles delete count = %d, want 1", fake.delClient["client-uuid-999"])
+	}
+	if fake.delClient["client-uuid-123"] != 0 {
+		t.Errorf("wanted client must not be cleaned up, got %d delete calls", fake.delClient["client-uuid-123"])
 	}
 }
 

--- a/test/e2e/user_roles_groups_test.go
+++ b/test/e2e/user_roles_groups_test.go
@@ -167,6 +167,146 @@ func TestKeycloakUserRolesGroupsE2E(t *testing.T) {
 		}), "group membership was not removed")
 	})
 
+	// Regression for #124. spec.clientRoles drives the composite role-mappings
+	// cleanup path, which no other subtest reaches. The user must reach Ready
+	// rather than RoleGroupReconcileError, and dropping a client from the map
+	// must actually remove its roles.
+	t.Run("ClientRoles", func(t *testing.T) {
+		if !canConnectToKeycloak() {
+			t.Skip("Skipping - cannot connect to Keycloak from test environment")
+		}
+
+		suffix := time.Now().UnixNano()
+		kc := getInternalKeycloakClient(t)
+
+		// Two clients, each carrying a role, so one can later go stale.
+		type testClient struct{ crName, clientID, role string }
+		clients := []testClient{
+			{fmt.Sprintf("cr-client-a-%d", suffix), fmt.Sprintf("client-a-%d", suffix), "role-a"},
+			{fmt.Sprintf("cr-client-b-%d", suffix), fmt.Sprintf("client-b-%d", suffix), "role-b"},
+		}
+		for _, c := range clients {
+			clientDef := rawJSON(`{"enabled": true, "serviceAccountsEnabled": true}`)
+			client := &keycloakv1beta1.KeycloakClient{
+				ObjectMeta: metav1.ObjectMeta{Name: c.crName, Namespace: testNamespace},
+				Spec: keycloakv1beta1.KeycloakClientSpec{
+					RealmRef:   &keycloakv1beta1.ResourceRef{Name: realmName},
+					ClientId:   strPtr(c.clientID),
+					Definition: &clientDef,
+				},
+			}
+			require.NoError(t, k8sClient.Create(ctx, client))
+			t.Cleanup(func() { k8sClient.Delete(ctx, client) })
+
+			require.NoError(t, wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+				updated := &keycloakv1beta1.KeycloakClient{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: c.crName, Namespace: testNamespace}, updated); err != nil {
+					return false, nil
+				}
+				return updated.Status.Ready, nil
+			}), "KeycloakClient %s did not become ready", c.crName)
+
+			role := &keycloakv1beta1.KeycloakRole{
+				ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-role", c.crName), Namespace: testNamespace},
+				Spec: keycloakv1beta1.KeycloakRoleSpec{
+					RealmRef:   &keycloakv1beta1.ResourceRef{Name: realmName},
+					ClientRef:  &keycloakv1beta1.ResourceRef{Name: c.crName},
+					Name:       strPtr(c.role),
+					Definition: rawJSON(`{"description": "e2e client role"}`),
+				},
+			}
+			require.NoError(t, k8sClient.Create(ctx, role))
+			t.Cleanup(func() { k8sClient.Delete(ctx, role) })
+
+			require.NoError(t, wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+				updated := &keycloakv1beta1.KeycloakRole{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: fmt.Sprintf("%s-role", c.crName), Namespace: testNamespace}, updated); err != nil {
+					return false, nil
+				}
+				return updated.Status.Ready, nil
+			}), "KeycloakRole for %s did not become ready", c.crName)
+		}
+
+		userName := fmt.Sprintf("client-roles-user-%d", suffix)
+		userDef := rawJSON(`{"enabled": true}`)
+		kcUser := &keycloakv1beta1.KeycloakUser{
+			ObjectMeta: metav1.ObjectMeta{Name: userName, Namespace: testNamespace},
+			Spec: keycloakv1beta1.KeycloakUserSpec{
+				RealmRef:   &keycloakv1beta1.ResourceRef{Name: realmName},
+				Username:   strPtr(userName),
+				Definition: &userDef,
+				ClientRoles: &map[string][]string{
+					clients[0].clientID: {clients[0].role},
+					clients[1].clientID: {clients[1].role},
+				},
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, kcUser))
+		t.Cleanup(func() { k8sClient.Delete(ctx, kcUser) })
+
+		// Before the fix this never became Ready: the stale-cleanup pass treated
+		// every client mapping as orphaned and deleted it via a clientId-shaped
+		// path, so each reconcile ended in RoleGroupReconcileError.
+		updated := waitUserReady(t, userName)
+		userID := updated.Status.UserID
+		require.NotEmpty(t, userID)
+
+		clientRoleNames := func(clientID string) func(context.Context) ([]string, error) {
+			return func(ctx context.Context) ([]string, error) {
+				rep, err := kc.GetClientByClientID(ctx, realmName, clientID)
+				if err != nil {
+					return nil, err
+				}
+				mappings, err := kc.GetUserClientRoleMappings(ctx, realmName, userID, *rep.ID)
+				if err != nil {
+					return nil, err
+				}
+				var names []string
+				for _, m := range mappings {
+					if m.Name != nil {
+						names = append(names, *m.Name)
+					}
+				}
+				return names, nil
+			}
+		}
+
+		for _, c := range clients {
+			require.NoError(t, wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+				names, err := clientRoleNames(c.clientID)(ctx)
+				if err != nil {
+					return false, nil
+				}
+				return len(names) == 1 && names[0] == c.role, nil
+			}), "client role %s was not assigned on %s", c.role, c.clientID)
+		}
+
+		// Drop the second client from the map: its roles must be cleaned up while
+		// the first client keeps its own.
+		require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: userName, Namespace: testNamespace}, kcUser))
+		kcUser.Spec.ClientRoles = &map[string][]string{
+			clients[0].clientID: {clients[0].role},
+		}
+		require.NoError(t, k8sClient.Update(ctx, kcUser))
+
+		require.NoError(t, wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+			names, err := clientRoleNames(clients[1].clientID)(ctx)
+			if err != nil {
+				return false, nil
+			}
+			return len(names) == 0, nil
+		}), "stale client roles on %s were not cleaned up", clients[1].clientID)
+
+		names, err := clientRoleNames(clients[0].clientID)(ctx)
+		require.NoError(t, err)
+		require.Equal(t, []string{clients[0].role}, names, "roles on the still-wanted client must survive cleanup")
+
+		// The user stays Ready after the cleanup pass.
+		final := &keycloakv1beta1.KeycloakUser{}
+		require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: userName, Namespace: testNamespace}, final))
+		require.True(t, final.Status.Ready, "user should remain ready (status: %s, message: %s)", final.Status.Status, final.Status.Message)
+	})
+
 	// Role/group keys inside spec.definition violate the one-home invariant.
 	t.Run("DefinitionRoleKeysRejected", func(t *testing.T) {
 		userName := fmt.Sprintf("def-roles-user-%d", time.Now().UnixNano())


### PR DESCRIPTION
## Description

Fixes #124.

A `KeycloakUser` that holds any client roles reports `RoleGroupReconcileError` on every reconcile, even though the roles are applied correctly.

### Root cause

Keycloak's composite endpoint `GET /admin/realms/{realm}/users/{id}/role-mappings` returns `clientMappings` **keyed by clientId**, with the client UUID carried inside each entry:

```json
"clientMappings": {
  "example-realm": { "id": "<client-uuid>", "client": "example-realm", "mappings": [...] }
}
```

Every other client role-mapping endpoint addresses the client by **UUID**. The stale-cleanup loop treated the map key as a UUID, which broke it twice over:

1. `wantedUUIDs[clientUUID]` compared a clientId against a set of UUIDs, so it never matched and **every** client mapping looked stale.
2. The subsequent delete was issued against a clientId-shaped path, so Keycloak answered `404 Client not found`.

That 404 is what surfaces as `RoleGroupReconcileError`. It is also the only reason the bug was not destructive — the deletes the operator wrongly decided to make all failed before touching anything.

The reporter's log line shows it plainly: `"clientUUID": "example-realm"` is a clientId, not a UUID.

### Second, silent bug

Because the wanted-set check never matched, **stale cleanup has never worked**. Removing a client key from `spec.clientRoles` did not remove the roles; the delete always 404'd. That is fixed here too and covered by a new test.

### Fix

Take the UUID from `entry.ID`, which the response already provides, for both the wanted-set check and the delete. The clientId is kept for logging and error messages, where it is the more useful identifier.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing

**Why the existing tests missed this:** the fake Keycloak built its composite response with `ID: uuid, Client: uuid`, keyed by UUID — modelling clientId and UUID as the same value, the exact conflation the production code made. The fake now keys `clientMappings` by clientId, carries the real UUID in `id`, and returns `404 Client not found` for an unknown UUID on the role-mapping path, matching Keycloak.

With that corrected and **before** the production fix, three tests fail with the reported error:

```
--- FAIL: TestReconcileUserClientRoles_Partial
    reconcileUserClientRoles: stale cleanup for client my-app: 404 Not Found: {"error":"Client not found"}
--- FAIL: TestReconcileUserClientRoles_WantedClientIsNotStale
    reconcileUserClientRoles: stale cleanup for client my-app: 404 Not Found: {"error":"Client not found"}
--- FAIL: TestReconcileUserClientRoles_StaleClientCleanedUp
    reconcileUserClientRoles: stale cleanup for client legacy-app: 404 Not Found: {"error":"Client not found"}
```

Note that `_Partial` is pre-existing — it was only passing because of the fake's flawed model.

New tests:

- `TestReconcileUserClientRoles_WantedClientIsNotStale` — reproduces #124. A client still named in `spec.clientRoles` must not be treated as stale; asserts no error and no delete call.
- `TestReconcileUserClientRoles_StaleClientCleanedUp` — covers the silent bug. Roles left on a client no longer in the spec are deleted, addressed by UUID, while the wanted client is left alone.

`make fmt`, `make vet` and `make test` pass; `make manifests` produces no changes.