### PR TITLE
feat!: derive a child resource's realm from its parent ref

### DIFF
--- a/api/v1beta1/crd_validation_test.go
+++ b/api/v1beta1/crd_validation_test.go
@@ -50,6 +50,7 @@ func TestCRDReferenceChoiceValidation(t *testing.T) {
 	clientRef := &ResourceRef{Name: "client"}
 	clientID := "client-id"
 	mapperName := "mapper"
+	groupName := "group"
 
 	tests := []struct {
 		name        string
@@ -138,7 +139,62 @@ func TestCRDReferenceChoiceValidation(t *testing.T) {
 					Role: &RoleDefinition{Name: "role"},
 				},
 			},
-			wantErrText: "exactly one of userRef or groupRef must be set",
+			wantErrText: "exactly one of userRef, groupRef, or serviceAccountRef must be set",
+		},
+		{
+			name: "KeycloakRoleMapping accepts a service account subject alone",
+			object: &KeycloakRoleMapping{
+				ObjectMeta: metav1.ObjectMeta{Name: "mapping-sa-subject", Namespace: namespace},
+				Spec: KeycloakRoleMappingSpec{
+					Subject: RoleMappingSubject{ServiceAccountRef: clientRef},
+					Role:    &RoleDefinition{Name: "role"},
+				},
+			},
+		},
+		{
+			name: "KeycloakRoleMapping rejects a subject with no reference",
+			object: &KeycloakRoleMapping{
+				ObjectMeta: metav1.ObjectMeta{Name: "mapping-no-subject", Namespace: namespace},
+				Spec: KeycloakRoleMappingSpec{
+					Role: &RoleDefinition{Name: "role"},
+				},
+			},
+			wantErrText: "exactly one of userRef, groupRef, or serviceAccountRef must be set",
+		},
+		{
+			name: "KeycloakGroup accepts a parent group alone",
+			object: &KeycloakGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: "group-nested", Namespace: namespace},
+				Spec: KeycloakGroupSpec{
+					Name:           &groupName,
+					ParentGroupRef: &ResourceRef{Name: "parent"},
+					Definition:     runtime.RawExtension{Raw: []byte(`{}`)},
+				},
+			},
+		},
+		{
+			name: "KeycloakGroup rejects a parent group beside a realm reference",
+			object: &KeycloakGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: "group-both", Namespace: namespace},
+				Spec: KeycloakGroupSpec{
+					Name:           &groupName,
+					RealmRef:       &ResourceRef{Name: "realm"},
+					ParentGroupRef: &ResourceRef{Name: "parent"},
+					Definition:     runtime.RawExtension{Raw: []byte(`{}`)},
+				},
+			},
+			wantErrText: "exactly one of realmRef, clusterRealmRef, or parentGroupRef must be set",
+		},
+		{
+			name: "KeycloakGroup rejects no parent reference",
+			object: &KeycloakGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: "group-none", Namespace: namespace},
+				Spec: KeycloakGroupSpec{
+					Name:       &groupName,
+					Definition: runtime.RawExtension{Raw: []byte(`{}`)},
+				},
+			},
+			wantErrText: "exactly one of realmRef, clusterRealmRef, or parentGroupRef must be set",
 		},
 		{
 			name: "RoleDefinition rejects both client selectors",

--- a/api/v1beta1/keycloakgroup_types.go
+++ b/api/v1beta1/keycloakgroup_types.go
@@ -6,20 +6,23 @@ import (
 )
 
 // KeycloakGroupSpec defines the desired state of KeycloakGroup
-// +kubebuilder:validation:XValidation:rule="has(self.realmRef) != has(self.clusterRealmRef)",message="exactly one of realmRef or clusterRealmRef must be set"
+// +kubebuilder:validation:XValidation:rule="(has(self.realmRef) ? 1 : 0) + (has(self.clusterRealmRef) ? 1 : 0) + (has(self.parentGroupRef) ? 1 : 0) == 1",message="exactly one of realmRef, clusterRealmRef, or parentGroupRef must be set"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.name) || self.name == oldSelf.name",message="spec.name is immutable once set"
 type KeycloakGroupSpec struct {
-	// RealmRef is a reference to a KeycloakRealm
-	// One of realmRef or clusterRealmRef must be specified
+	// RealmRef is a reference to a KeycloakRealm for top-level groups
+	// One of realmRef, clusterRealmRef, or parentGroupRef must be specified
 	// +optional
 	RealmRef *ResourceRef `json:"realmRef,omitempty"`
 
-	// ClusterRealmRef is a reference to a ClusterKeycloakRealm
-	// One of realmRef or clusterRealmRef must be specified
+	// ClusterRealmRef is a reference to a ClusterKeycloakRealm for top-level groups
+	// One of realmRef, clusterRealmRef, or parentGroupRef must be specified
 	// +optional
 	ClusterRealmRef *ClusterResourceRef `json:"clusterRealmRef,omitempty"`
 
-	// ParentGroupRef is a reference to a parent KeycloakGroup (for nested groups)
+	// ParentGroupRef is a reference to a parent KeycloakGroup for nested groups.
+	// The realm is derived from the parent chain, so realmRef and clusterRealmRef
+	// must not be set alongside it.
+	// One of realmRef, clusterRealmRef, or parentGroupRef must be specified
 	// +optional
 	ParentGroupRef *ResourceRef `json:"parentGroupRef,omitempty"`
 

--- a/api/v1beta1/keycloakrole_types.go
+++ b/api/v1beta1/keycloakrole_types.go
@@ -6,21 +6,23 @@ import (
 )
 
 // KeycloakRoleSpec defines the desired state of KeycloakRole
-// +kubebuilder:validation:XValidation:rule="has(self.realmRef) != has(self.clusterRealmRef)",message="exactly one of realmRef or clusterRealmRef must be set"
+// +kubebuilder:validation:XValidation:rule="(has(self.realmRef) ? 1 : 0) + (has(self.clusterRealmRef) ? 1 : 0) + (has(self.clientRef) ? 1 : 0) == 1",message="exactly one of realmRef, clusterRealmRef, or clientRef must be set"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.name) || self.name == oldSelf.name",message="spec.name is immutable once set"
 type KeycloakRoleSpec struct {
-	// RealmRef is a reference to a KeycloakRealm
-	// One of realmRef or clusterRealmRef must be specified
+	// RealmRef is a reference to a KeycloakRealm for realm-level roles
+	// One of realmRef, clusterRealmRef, or clientRef must be specified
 	// +optional
 	RealmRef *ResourceRef `json:"realmRef,omitempty"`
 
-	// ClusterRealmRef is a reference to a ClusterKeycloakRealm
-	// One of realmRef or clusterRealmRef must be specified
+	// ClusterRealmRef is a reference to a ClusterKeycloakRealm for realm-level roles
+	// One of realmRef, clusterRealmRef, or clientRef must be specified
 	// +optional
 	ClusterRealmRef *ClusterResourceRef `json:"clusterRealmRef,omitempty"`
 
-	// ClientRef is a reference to a KeycloakClient for client-level roles
-	// If not specified, the role is a realm-level role
+	// ClientRef is a reference to a KeycloakClient for client-level roles.
+	// The realm is derived from the referenced client, so realmRef and
+	// clusterRealmRef must not be set alongside it.
+	// One of realmRef, clusterRealmRef, or clientRef must be specified
 	// +optional
 	ClientRef *ResourceRef `json:"clientRef,omitempty"`
 

--- a/api/v1beta1/keycloakrolemapping_types.go
+++ b/api/v1beta1/keycloakrolemapping_types.go
@@ -23,7 +23,7 @@ type KeycloakRoleMappingSpec struct {
 }
 
 // RoleMappingSubject defines the target of the role mapping
-// +kubebuilder:validation:XValidation:rule="has(self.userRef) != has(self.groupRef)",message="exactly one of userRef or groupRef must be set"
+// +kubebuilder:validation:XValidation:rule="(has(self.userRef) ? 1 : 0) + (has(self.groupRef) ? 1 : 0) + (has(self.serviceAccountRef) ? 1 : 0) == 1",message="exactly one of userRef, groupRef, or serviceAccountRef must be set"
 type RoleMappingSubject struct {
 	// UserRef references a KeycloakUser
 	// +optional

--- a/charts/keycloak-operator/files/crds/keycloak.hostzero.com_keycloakgroups.yaml
+++ b/charts/keycloak-operator/files/crds/keycloak.hostzero.com_keycloakgroups.yaml
@@ -62,8 +62,8 @@ spec:
             properties:
               clusterRealmRef:
                 description: |-
-                  ClusterRealmRef is a reference to a ClusterKeycloakRealm
-                  One of realmRef or clusterRealmRef must be specified
+                  ClusterRealmRef is a reference to a ClusterKeycloakRealm for top-level groups
+                  One of realmRef, clusterRealmRef, or parentGroupRef must be specified
                 properties:
                   name:
                     description: Name of the cluster-scoped resource
@@ -82,8 +82,11 @@ spec:
                 minLength: 1
                 type: string
               parentGroupRef:
-                description: ParentGroupRef is a reference to a parent KeycloakGroup
-                  (for nested groups)
+                description: |-
+                  ParentGroupRef is a reference to a parent KeycloakGroup for nested groups.
+                  The realm is derived from the parent chain, so realmRef and clusterRealmRef
+                  must not be set alongside it.
+                  One of realmRef, clusterRealmRef, or parentGroupRef must be specified
                 properties:
                   name:
                     description: Name of the resource
@@ -93,8 +96,8 @@ spec:
                 type: object
               realmRef:
                 description: |-
-                  RealmRef is a reference to a KeycloakRealm
-                  One of realmRef or clusterRealmRef must be specified
+                  RealmRef is a reference to a KeycloakRealm for top-level groups
+                  One of realmRef, clusterRealmRef, or parentGroupRef must be specified
                 properties:
                   name:
                     description: Name of the resource
@@ -107,8 +110,10 @@ spec:
             - name
             type: object
             x-kubernetes-validations:
-            - message: exactly one of realmRef or clusterRealmRef must be set
-              rule: has(self.realmRef) != has(self.clusterRealmRef)
+            - message: exactly one of realmRef, clusterRealmRef, or parentGroupRef
+                must be set
+              rule: '(has(self.realmRef) ? 1 : 0) + (has(self.clusterRealmRef) ? 1
+                : 0) + (has(self.parentGroupRef) ? 1 : 0) == 1'
             - message: spec.name is immutable once set
               rule: '!has(oldSelf.name) || self.name == oldSelf.name'
           status:

--- a/charts/keycloak-operator/files/crds/keycloak.hostzero.com_keycloakrolemappings.yaml
+++ b/charts/keycloak-operator/files/crds/keycloak.hostzero.com_keycloakrolemappings.yaml
@@ -140,8 +140,10 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-validations:
-                - message: exactly one of userRef or groupRef must be set
-                  rule: has(self.userRef) != has(self.groupRef)
+                - message: exactly one of userRef, groupRef, or serviceAccountRef
+                    must be set
+                  rule: '(has(self.userRef) ? 1 : 0) + (has(self.groupRef) ? 1 : 0)
+                    + (has(self.serviceAccountRef) ? 1 : 0) == 1'
             required:
             - subject
             type: object

--- a/charts/keycloak-operator/files/crds/keycloak.hostzero.com_keycloakroles.yaml
+++ b/charts/keycloak-operator/files/crds/keycloak.hostzero.com_keycloakroles.yaml
@@ -62,8 +62,10 @@ spec:
             properties:
               clientRef:
                 description: |-
-                  ClientRef is a reference to a KeycloakClient for client-level roles
-                  If not specified, the role is a realm-level role
+                  ClientRef is a reference to a KeycloakClient for client-level roles.
+                  The realm is derived from the referenced client, so realmRef and
+                  clusterRealmRef must not be set alongside it.
+                  One of realmRef, clusterRealmRef, or clientRef must be specified
                 properties:
                   name:
                     description: Name of the resource
@@ -73,8 +75,8 @@ spec:
                 type: object
               clusterRealmRef:
                 description: |-
-                  ClusterRealmRef is a reference to a ClusterKeycloakRealm
-                  One of realmRef or clusterRealmRef must be specified
+                  ClusterRealmRef is a reference to a ClusterKeycloakRealm for realm-level roles
+                  One of realmRef, clusterRealmRef, or clientRef must be specified
                 properties:
                   name:
                     description: Name of the cluster-scoped resource
@@ -94,8 +96,8 @@ spec:
                 type: string
               realmRef:
                 description: |-
-                  RealmRef is a reference to a KeycloakRealm
-                  One of realmRef or clusterRealmRef must be specified
+                  RealmRef is a reference to a KeycloakRealm for realm-level roles
+                  One of realmRef, clusterRealmRef, or clientRef must be specified
                 properties:
                   name:
                     description: Name of the resource
@@ -108,8 +110,10 @@ spec:
             - name
             type: object
             x-kubernetes-validations:
-            - message: exactly one of realmRef or clusterRealmRef must be set
-              rule: has(self.realmRef) != has(self.clusterRealmRef)
+            - message: exactly one of realmRef, clusterRealmRef, or clientRef must
+                be set
+              rule: '(has(self.realmRef) ? 1 : 0) + (has(self.clusterRealmRef) ? 1
+                : 0) + (has(self.clientRef) ? 1 : 0) == 1'
             - message: spec.name is immutable once set
               rule: '!has(oldSelf.name) || self.name == oldSelf.name'
           status:

--- a/config/crd/bases/keycloak.hostzero.com_keycloakgroups.yaml
+++ b/config/crd/bases/keycloak.hostzero.com_keycloakgroups.yaml
@@ -62,8 +62,8 @@ spec:
             properties:
               clusterRealmRef:
                 description: |-
-                  ClusterRealmRef is a reference to a ClusterKeycloakRealm
-                  One of realmRef or clusterRealmRef must be specified
+                  ClusterRealmRef is a reference to a ClusterKeycloakRealm for top-level groups
+                  One of realmRef, clusterRealmRef, or parentGroupRef must be specified
                 properties:
                   name:
                     description: Name of the cluster-scoped resource
@@ -82,8 +82,11 @@ spec:
                 minLength: 1
                 type: string
               parentGroupRef:
-                description: ParentGroupRef is a reference to a parent KeycloakGroup
-                  (for nested groups)
+                description: |-
+                  ParentGroupRef is a reference to a parent KeycloakGroup for nested groups.
+                  The realm is derived from the parent chain, so realmRef and clusterRealmRef
+                  must not be set alongside it.
+                  One of realmRef, clusterRealmRef, or parentGroupRef must be specified
                 properties:
                   name:
                     description: Name of the resource
@@ -93,8 +96,8 @@ spec:
                 type: object
               realmRef:
                 description: |-
-                  RealmRef is a reference to a KeycloakRealm
-                  One of realmRef or clusterRealmRef must be specified
+                  RealmRef is a reference to a KeycloakRealm for top-level groups
+                  One of realmRef, clusterRealmRef, or parentGroupRef must be specified
                 properties:
                   name:
                     description: Name of the resource
@@ -107,8 +110,10 @@ spec:
             - name
             type: object
             x-kubernetes-validations:
-            - message: exactly one of realmRef or clusterRealmRef must be set
-              rule: has(self.realmRef) != has(self.clusterRealmRef)
+            - message: exactly one of realmRef, clusterRealmRef, or parentGroupRef
+                must be set
+              rule: '(has(self.realmRef) ? 1 : 0) + (has(self.clusterRealmRef) ? 1
+                : 0) + (has(self.parentGroupRef) ? 1 : 0) == 1'
             - message: spec.name is immutable once set
               rule: '!has(oldSelf.name) || self.name == oldSelf.name'
           status:

--- a/config/crd/bases/keycloak.hostzero.com_keycloakrolemappings.yaml
+++ b/config/crd/bases/keycloak.hostzero.com_keycloakrolemappings.yaml
@@ -140,8 +140,10 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-validations:
-                - message: exactly one of userRef or groupRef must be set
-                  rule: has(self.userRef) != has(self.groupRef)
+                - message: exactly one of userRef, groupRef, or serviceAccountRef
+                    must be set
+                  rule: '(has(self.userRef) ? 1 : 0) + (has(self.groupRef) ? 1 : 0)
+                    + (has(self.serviceAccountRef) ? 1 : 0) == 1'
             required:
             - subject
             type: object

--- a/config/crd/bases/keycloak.hostzero.com_keycloakroles.yaml
+++ b/config/crd/bases/keycloak.hostzero.com_keycloakroles.yaml
@@ -62,8 +62,10 @@ spec:
             properties:
               clientRef:
                 description: |-
-                  ClientRef is a reference to a KeycloakClient for client-level roles
-                  If not specified, the role is a realm-level role
+                  ClientRef is a reference to a KeycloakClient for client-level roles.
+                  The realm is derived from the referenced client, so realmRef and
+                  clusterRealmRef must not be set alongside it.
+                  One of realmRef, clusterRealmRef, or clientRef must be specified
                 properties:
                   name:
                     description: Name of the resource
@@ -73,8 +75,8 @@ spec:
                 type: object
               clusterRealmRef:
                 description: |-
-                  ClusterRealmRef is a reference to a ClusterKeycloakRealm
-                  One of realmRef or clusterRealmRef must be specified
+                  ClusterRealmRef is a reference to a ClusterKeycloakRealm for realm-level roles
+                  One of realmRef, clusterRealmRef, or clientRef must be specified
                 properties:
                   name:
                     description: Name of the cluster-scoped resource
@@ -94,8 +96,8 @@ spec:
                 type: string
               realmRef:
                 description: |-
-                  RealmRef is a reference to a KeycloakRealm
-                  One of realmRef or clusterRealmRef must be specified
+                  RealmRef is a reference to a KeycloakRealm for realm-level roles
+                  One of realmRef, clusterRealmRef, or clientRef must be specified
                 properties:
                   name:
                     description: Name of the resource
@@ -108,8 +110,10 @@ spec:
             - name
             type: object
             x-kubernetes-validations:
-            - message: exactly one of realmRef or clusterRealmRef must be set
-              rule: has(self.realmRef) != has(self.clusterRealmRef)
+            - message: exactly one of realmRef, clusterRealmRef, or clientRef must
+                be set
+              rule: '(has(self.realmRef) ? 1 : 0) + (has(self.clusterRealmRef) ? 1
+                : 0) + (has(self.clientRef) ? 1 : 0) == 1'
             - message: spec.name is immutable once set
               rule: '!has(oldSelf.name) || self.name == oldSelf.name'
           status:

--- a/docs/src/crds.md
+++ b/docs/src/crds.md
@@ -112,6 +112,25 @@ For contributors, the layer of a new field follows mechanically:
 - Managed through a separate Keycloak API endpoint rather than the representation `PUT`? → its own CRD (like KeycloakRoleMapping) or a typed spec section — never keys inside `definition`.
 - Part of the Keycloak representation itself? → stays in `definition`, untyped.
 
+### Placement References
+
+**A resource names exactly one parent, and if that parent implies the realm, the realm is not named again.** Setting more than one, or none, is rejected at admission.
+
+| CRD | Placement refs |
+|-----|----------------|
+| `KeycloakRealm`, `ClusterKeycloakRealm` | `instanceRef` / `clusterInstanceRef` |
+| `KeycloakClient`, `KeycloakClientScope`, `KeycloakComponent`, `KeycloakOrganization`, `KeycloakIdentityProvider`, `KeycloakRequiredAction`, `KeycloakAuthenticationFlow` | `realmRef` / `clusterRealmRef` |
+| `KeycloakRole`, `KeycloakUser` | `realmRef` / `clusterRealmRef` / `clientRef` |
+| `KeycloakGroup` | `realmRef` / `clusterRealmRef` / `parentGroupRef` |
+| `KeycloakProtocolMapper` | `clientRef` / `clientScopeRef` |
+| `KeycloakRoleMapping` | `subject.userRef` / `subject.groupRef` / `subject.serviceAccountRef` |
+| `KeycloakIdentityProviderMapper` | `identityProviderRef` |
+| `KeycloakUserCredential` | `userRef` |
+
+Where a ref points at something below the realm, the realm is derived from it: a client role reads the realm of its `clientRef`, and a nested group inherits the realm carried by the root of its `parentGroupRef` chain. Restating it alongside would allow the two to disagree, which is why it is rejected rather than merely redundant.
+
+Secret and ConfigMap references (`clientSecretRef`, `smtpSecretRef`, `configSecretRef`, …) are layer 3, not placement, and are unaffected by this rule.
+
 ### Status Tracking
 
 All resources expose status information:

--- a/docs/src/crds/keycloakgroup.md
+++ b/docs/src/crds/keycloakgroup.md
@@ -12,17 +12,18 @@ kind: KeycloakGroup
 metadata:
   name: my-group
 spec:
-  # One of realmRef or clusterRealmRef must be specified
+  # Exactly one of realmRef, clusterRealmRef, or parentGroupRef must be specified
   
-  # Option 1: Reference to a namespaced KeycloakRealm
+  # Option 1: Reference to a namespaced KeycloakRealm (top-level group)
   realmRef:
     name: my-realm
   
-  # Option 2: Reference to a ClusterKeycloakRealm
+  # Option 2: Reference to a ClusterKeycloakRealm (top-level group)
   clusterRealmRef:
     name: my-cluster-realm
   
-  # Optional: Reference to parent group (for nested groups)
+  # Option 3: Reference to a parent group (nested group; the realm comes from
+  # the parent chain, so do not also set realmRef)
   parentGroupRef:
     name: parent-group
   
@@ -102,7 +103,8 @@ spec:
   definition: {}
 ```
 
-Then create child groups:
+Then create child groups. A nested group names only its parent; the realm is
+inherited from the parent chain:
 
 ```yaml
 apiVersion: keycloak.hostzero.com/v1beta1
@@ -110,8 +112,6 @@ kind: KeycloakGroup
 metadata:
   name: team-alpha
 spec:
-  realmRef:
-    name: my-realm
   parentGroupRef:
     name: organization
   name: team-alpha

--- a/docs/src/crds/keycloakgroup.md
+++ b/docs/src/crds/keycloakgroup.md
@@ -118,6 +118,24 @@ spec:
   definition: {}
 ```
 
+Groups may nest arbitrarily deep. Each level names only its immediate parent, and
+the realm is resolved by following the chain up to the top-level group.
+
+## Parent Reference
+
+A `KeycloakGroup` belongs to one of three parents:
+
+| Reference | Scope | Use Case |
+|-----------|-------|----------|
+| `realmRef` | Top-level group | Group directly under a realm |
+| `clusterRealmRef` | Top-level group | For cluster-scoped realms |
+| `parentGroupRef` | Nested group | Subgroup of another `KeycloakGroup` |
+
+**Note:** Exactly one of these must be specified; setting more than one is rejected.
+
+For a nested group, use `parentGroupRef` alone. The realm is inherited from the
+parent chain, so `realmRef` and `clusterRealmRef` must not be combined with it.
+
 ## Definition Properties
 
 | Property | Type | Description |

--- a/docs/src/crds/keycloakrole.md
+++ b/docs/src/crds/keycloakrole.md
@@ -12,13 +12,13 @@ kind: KeycloakRole
 metadata:
   name: my-role
 spec:
-  # One of realmRef, clusterRealmRef, or clientRef must be specified
+  # Exactly one of realmRef, clusterRealmRef, or clientRef must be specified
   
   # For realm roles:
   realmRef:
     name: my-realm
   
-  # For client roles:
+  # For client roles (the realm comes from the client; do not also set realmRef):
   # clientRef:
   #   name: my-client
   
@@ -70,6 +70,8 @@ spec:
 
 ### Client Role
 
+The realm is derived from the referenced client, so no `realmRef` is given:
+
 ```yaml
 apiVersion: keycloak.hostzero.com/v1beta1
 kind: KeycloakRole
@@ -94,7 +96,11 @@ A `KeycloakRole` can belong to one of three parent types:
 | `clusterRealmRef` | Realm role | For cluster-scoped realms |
 | `clientRef` | Client role | Specific to a single client |
 
-**Note:** Exactly one of these must be specified.
+**Note:** Exactly one of these must be specified; setting more than one is rejected.
+
+For a client role, use `clientRef` alone. The realm is taken from the referenced
+client, which already belongs to exactly one realm, so `realmRef` and
+`clusterRealmRef` must not be combined with `clientRef`.
 
 ## Definition Properties
 

--- a/internal/controller/keycloakgroup_controller.go
+++ b/internal/controller/keycloakgroup_controller.go
@@ -82,8 +82,12 @@ func (r *KeycloakGroupReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// Get Keycloak client and realm info
 	kc, realmName, err := r.getKeycloakClientAndRealm(ctx, group)
 	if err != nil {
-		RecordError(controllerName, "realm_not_ready")
-		return r.updateStatus(ctx, group, false, "RealmNotReady", err.Error(), "")
+		reason, metric := "RealmNotReady", "realm_not_ready"
+		if group.Spec.ParentGroupRef != nil {
+			reason, metric = "ParentNotReady", "parent_not_ready"
+		}
+		RecordError(controllerName, metric)
+		return r.updateStatus(ctx, group, false, reason, err.Error(), "")
 	}
 
 	// Parse group definition to extract name
@@ -197,20 +201,27 @@ func findTopLevelGroupByName(groups []keycloak.GroupRepresentation, name string)
 	return nil
 }
 
+// maxGroupNestingDepth caps the parentGroupRef walk. Keycloak imposes no limit on
+// nesting; the cap only turns an accidental reference cycle into an error rather
+// than an unbounded walk.
+const maxGroupNestingDepth = 100
+
 func (r *KeycloakGroupReconciler) getKeycloakClientAndRealm(ctx context.Context, group *keycloakv1beta1.KeycloakGroup) (*keycloak.Client, string, error) {
-	// Check if using cluster realm ref
-	if group.Spec.ClusterRealmRef != nil {
-		return r.getKeycloakClientFromClusterRealm(ctx, group.Spec.ClusterRealmRef.Name)
+	// A nested group names no realm of its own; it inherits the one carried by the
+	// root of its parent chain.
+	owner, err := r.resolveRealmOwner(ctx, group)
+	if err != nil {
+		return nil, "", err
 	}
 
-	// Use namespaced realm ref
-	if group.Spec.RealmRef == nil {
-		return nil, "", fmt.Errorf("either realmRef or clusterRealmRef must be specified")
+	// Check if using cluster realm ref
+	if owner.Spec.ClusterRealmRef != nil {
+		return r.getKeycloakClientFromClusterRealm(ctx, owner.Spec.ClusterRealmRef.Name)
 	}
 
 	realmName := types.NamespacedName{
-		Name:      group.Spec.RealmRef.Name,
-		Namespace: group.Namespace,
+		Name:      owner.Spec.RealmRef.Name,
+		Namespace: owner.Namespace,
 	}
 
 	// Get the KeycloakRealm
@@ -231,6 +242,40 @@ func (r *KeycloakGroupReconciler) getKeycloakClientAndRealm(ctx context.Context,
 	// The realm name is the referenced realm's resolved identifier (spec.realmName,
 	// surfaced via status); it is never read from the realm's definition.
 	return kc, realm.Status.RealmName, nil
+}
+
+// resolveRealmOwner walks parentGroupRef upwards and returns the ancestor that
+// carries the realm reference, which for a top-level group is the group itself.
+func (r *KeycloakGroupReconciler) resolveRealmOwner(ctx context.Context, group *keycloakv1beta1.KeycloakGroup) (*keycloakv1beta1.KeycloakGroup, error) {
+	current := group
+	seen := make(map[string]bool, 1)
+
+	for range maxGroupNestingDepth {
+		if current.Spec.ParentGroupRef == nil {
+			if current.Spec.RealmRef == nil && current.Spec.ClusterRealmRef == nil {
+				return nil, fmt.Errorf("KeycloakGroup %s/%s has no realmRef or clusterRealmRef", current.Namespace, current.Name)
+			}
+			return current, nil
+		}
+
+		key := current.Namespace + "/" + current.Name
+		if seen[key] {
+			return nil, fmt.Errorf("parentGroupRef cycle detected at KeycloakGroup %s", key)
+		}
+		seen[key] = true
+
+		parentKey := types.NamespacedName{
+			Name:      current.Spec.ParentGroupRef.Name,
+			Namespace: current.Namespace,
+		}
+		parent := &keycloakv1beta1.KeycloakGroup{}
+		if err := r.Get(ctx, parentKey, parent); err != nil {
+			return nil, fmt.Errorf("failed to get parent KeycloakGroup %s: %w", parentKey, err)
+		}
+		current = parent
+	}
+
+	return nil, fmt.Errorf("parentGroupRef chain from KeycloakGroup %s/%s exceeds %d levels", group.Namespace, group.Name, maxGroupNestingDepth)
 }
 
 func (r *KeycloakGroupReconciler) getKeycloakClientFromClusterRealm(ctx context.Context, clusterRealmName string) (*keycloak.Client, string, error) {

--- a/internal/controller/keycloakgroup_controller_test.go
+++ b/internal/controller/keycloakgroup_controller_test.go
@@ -1,8 +1,14 @@
 package controller
 
 import (
+	"context"
+	"strings"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	keycloakv1beta1 "github.com/Hostzero-GmbH/keycloak-operator/api/v1beta1"
 	"github.com/Hostzero-GmbH/keycloak-operator/internal/keycloak"
 )
 
@@ -27,5 +33,89 @@ func TestFindTopLevelGroupByName(t *testing.T) {
 	}
 	if got := findTopLevelGroupByName(groups, "nested"); got != nil {
 		t.Errorf("findTopLevelGroupByName must not recurse into SubGroups, got %+v", got)
+	}
+}
+
+func nestedGroup(name, parent, realm string) *keycloakv1beta1.KeycloakGroup {
+	g := &keycloakv1beta1.KeycloakGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+	}
+	if parent != "" {
+		g.Spec.ParentGroupRef = &keycloakv1beta1.ResourceRef{Name: parent}
+	}
+	if realm != "" {
+		g.Spec.RealmRef = &keycloakv1beta1.ResourceRef{Name: realm}
+	}
+	return g
+}
+
+// A nested group carries no realm ref, so the realm is only reachable by walking
+// parentGroupRef to the root of the chain.
+func TestResolveRealmOwner_WalksToRoot(t *testing.T) {
+	root := nestedGroup("root", "", "my-realm")
+	mid := nestedGroup("mid", "root", "")
+	leaf := nestedGroup("leaf", "mid", "")
+
+	r := &KeycloakGroupReconciler{
+		Client: fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(root, mid, leaf).Build(),
+	}
+
+	owner, err := r.resolveRealmOwner(context.Background(), leaf)
+	if err != nil {
+		t.Fatalf("resolveRealmOwner: %v", err)
+	}
+	if owner.Name != "root" {
+		t.Errorf("owner = %q, want root", owner.Name)
+	}
+	if owner.Spec.RealmRef == nil || owner.Spec.RealmRef.Name != "my-realm" {
+		t.Errorf("owner realmRef = %+v, want my-realm", owner.Spec.RealmRef)
+	}
+}
+
+func TestResolveRealmOwner_TopLevelIsItsOwnOwner(t *testing.T) {
+	root := nestedGroup("root", "", "my-realm")
+	r := &KeycloakGroupReconciler{
+		Client: fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(root).Build(),
+	}
+
+	owner, err := r.resolveRealmOwner(context.Background(), root)
+	if err != nil {
+		t.Fatalf("resolveRealmOwner: %v", err)
+	}
+	if owner.Name != "root" {
+		t.Errorf("owner = %q, want root", owner.Name)
+	}
+}
+
+// A cycle must surface as an error rather than walk until the depth cap.
+func TestResolveRealmOwner_CycleIsRejected(t *testing.T) {
+	a := nestedGroup("a", "b", "")
+	b := nestedGroup("b", "a", "")
+
+	r := &KeycloakGroupReconciler{
+		Client: fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(a, b).Build(),
+	}
+
+	_, err := r.resolveRealmOwner(context.Background(), a)
+	if err == nil {
+		t.Fatal("expected an error for a parentGroupRef cycle, got nil")
+	}
+	if !strings.Contains(err.Error(), "cycle") {
+		t.Errorf("error should name the cycle, got %q", err)
+	}
+}
+
+func TestResolveRealmOwner_MissingParentIsReported(t *testing.T) {
+	leaf := nestedGroup("leaf", "gone", "")
+	r := &KeycloakGroupReconciler{
+		Client: fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(leaf).Build(),
+	}
+
+	_, err := r.resolveRealmOwner(context.Background(), leaf)
+	if err == nil {
+		t.Fatal("expected an error when the parent group is absent, got nil")
+	}
+	if !strings.Contains(err.Error(), "gone") {
+		t.Errorf("error should name the missing parent, got %q", err)
 	}
 }

--- a/internal/controller/keycloakrole_controller.go
+++ b/internal/controller/keycloakrole_controller.go
@@ -79,11 +79,15 @@ func (r *KeycloakRoleReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{Requeue: true}, nil
 	}
 
-	// Get Keycloak client and realm info
-	kc, realmName, err := r.getKeycloakClientAndRealm(ctx, role)
+	// Get Keycloak client, realm, and (for client roles) the owning client UUID
+	kc, realmName, clientUUID, err := r.getKeycloakClientAndRealm(ctx, role)
 	if err != nil {
-		RecordError(controllerName, "realm_not_ready")
-		return r.updateStatus(ctx, role, false, "RealmNotReady", err.Error(), "", "", false, "")
+		reason, metric := "RealmNotReady", "realm_not_ready"
+		if role.Spec.ClientRef != nil {
+			reason, metric = "ClientNotReady", "client_not_ready"
+		}
+		RecordError(controllerName, metric)
+		return r.updateStatus(ctx, role, false, reason, err.Error(), "", "", false, "")
 	}
 
 	// Parse role definition to extract name
@@ -109,15 +113,7 @@ func (r *KeycloakRoleReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	desiredComposites, compositesRequested := extractRoleComposites(definition)
 	definition = removeFieldFromDefinition(definition, "composites")
 
-	var clientUUID string
 	isClientRole := role.Spec.ClientRef != nil
-	if isClientRole {
-		clientUUID, err = r.getClientUUID(ctx, role)
-		if err != nil {
-			RecordError(controllerName, "client_not_ready")
-			return r.updateStatus(ctx, role, false, "ClientNotReady", err.Error(), "", "", false, "")
-		}
-	}
 
 	var roleID string
 	if isClientRole {
@@ -297,15 +293,24 @@ func resolveRoleComposites(
 	return resolved, nil
 }
 
-func (r *KeycloakRoleReconciler) getKeycloakClientAndRealm(ctx context.Context, role *keycloakv1beta1.KeycloakRole) (*keycloak.Client, string, error) {
+// getKeycloakClientAndRealm resolves the Keycloak connection, the realm the role
+// belongs to, and — for client roles — the owning client's UUID. A client role
+// carries only clientRef; its realm is taken from the referenced client so the
+// realm is never stated twice.
+func (r *KeycloakRoleReconciler) getKeycloakClientAndRealm(ctx context.Context, role *keycloakv1beta1.KeycloakRole) (*keycloak.Client, string, string, error) {
+	if role.Spec.ClientRef != nil {
+		return r.getKeycloakClientAndRealmFromClient(ctx, role)
+	}
+
 	// Check if using cluster realm ref
 	if role.Spec.ClusterRealmRef != nil {
-		return r.getKeycloakClientFromClusterRealm(ctx, role.Spec.ClusterRealmRef.Name)
+		kc, realmName, err := r.getKeycloakClientFromClusterRealm(ctx, role.Spec.ClusterRealmRef.Name)
+		return kc, realmName, "", err
 	}
 
 	// Use namespaced realm ref
 	if role.Spec.RealmRef == nil {
-		return nil, "", fmt.Errorf("either realmRef or clusterRealmRef must be specified")
+		return nil, "", "", fmt.Errorf("exactly one of realmRef, clusterRealmRef, or clientRef must be specified")
 	}
 
 	realmName := types.NamespacedName{
@@ -316,21 +321,76 @@ func (r *KeycloakRoleReconciler) getKeycloakClientAndRealm(ctx context.Context, 
 	// Get the KeycloakRealm
 	realm := &keycloakv1beta1.KeycloakRealm{}
 	if err := r.Get(ctx, realmName, realm); err != nil {
-		return nil, "", fmt.Errorf("failed to get KeycloakRealm %s: %w", realmName, err)
+		return nil, "", "", fmt.Errorf("failed to get KeycloakRealm %s: %w", realmName, err)
 	}
 
 	if !realm.Status.Ready || realm.Status.RealmName == "" {
-		return nil, "", fmt.Errorf("KeycloakRealm %s is not ready", realmName)
+		return nil, "", "", fmt.Errorf("KeycloakRealm %s is not ready", realmName)
 	}
 
 	kc, _, err := GetKeycloakClientFromRealmInstance(ctx, r.Client, r.ClientManager, realm)
 	if err != nil {
-		return nil, "", err
+		return nil, "", "", err
 	}
 
 	// The realm name is the referenced realm's resolved identifier (spec.realmName,
 	// surfaced via status); it is never read from the realm's definition.
-	return kc, realm.Status.RealmName, nil
+	return kc, realm.Status.RealmName, "", nil
+}
+
+// getKeycloakClientAndRealmFromClient resolves a client role's realm by following
+// the referenced client's own realm reference.
+func (r *KeycloakRoleReconciler) getKeycloakClientAndRealmFromClient(ctx context.Context, role *keycloakv1beta1.KeycloakRole) (*keycloak.Client, string, string, error) {
+	clientKey := types.NamespacedName{
+		Name:      role.Spec.ClientRef.Name,
+		Namespace: role.Namespace,
+	}
+
+	kcClient := &keycloakv1beta1.KeycloakClient{}
+	if err := r.Get(ctx, clientKey, kcClient); err != nil {
+		return nil, "", "", fmt.Errorf("failed to get KeycloakClient %s: %w", clientKey, err)
+	}
+
+	if !kcClient.Status.Ready {
+		return nil, "", "", fmt.Errorf("KeycloakClient %s is not ready", clientKey)
+	}
+
+	if kcClient.Status.ClientUUID == "" {
+		return nil, "", "", fmt.Errorf("KeycloakClient %s has no clientUUID", clientKey)
+	}
+
+	if kcClient.Spec.ClusterRealmRef != nil {
+		kc, realmName, err := r.getKeycloakClientFromClusterRealm(ctx, kcClient.Spec.ClusterRealmRef.Name)
+		if err != nil {
+			return nil, "", "", err
+		}
+		return kc, realmName, kcClient.Status.ClientUUID, nil
+	}
+
+	if kcClient.Spec.RealmRef == nil {
+		return nil, "", "", fmt.Errorf("KeycloakClient %s has no realmRef or clusterRealmRef", clientKey)
+	}
+
+	realmKey := types.NamespacedName{
+		Name:      kcClient.Spec.RealmRef.Name,
+		Namespace: kcClient.Namespace,
+	}
+
+	realm := &keycloakv1beta1.KeycloakRealm{}
+	if err := r.Get(ctx, realmKey, realm); err != nil {
+		return nil, "", "", fmt.Errorf("failed to get KeycloakRealm %s: %w", realmKey, err)
+	}
+
+	if !realm.Status.Ready || realm.Status.RealmName == "" {
+		return nil, "", "", fmt.Errorf("KeycloakRealm %s is not ready", realmKey)
+	}
+
+	kc, _, err := GetKeycloakClientFromRealmInstance(ctx, r.Client, r.ClientManager, realm)
+	if err != nil {
+		return nil, "", "", err
+	}
+
+	return kc, realm.Status.RealmName, kcClient.Status.ClientUUID, nil
 }
 
 func (r *KeycloakRoleReconciler) getKeycloakClientFromClusterRealm(ctx context.Context, clusterRealmName string) (*keycloak.Client, string, error) {
@@ -402,34 +462,8 @@ func (r *KeycloakRoleReconciler) getKeycloakClientFromClusterRealm(ctx context.C
 	return kc, realmName, nil
 }
 
-func (r *KeycloakRoleReconciler) getClientUUID(ctx context.Context, role *keycloakv1beta1.KeycloakRole) (string, error) {
-	if role.Spec.ClientRef == nil {
-		return "", fmt.Errorf("clientRef is required for client roles")
-	}
-
-	clientName := types.NamespacedName{
-		Name:      role.Spec.ClientRef.Name,
-		Namespace: role.Namespace,
-	}
-
-	kcClient := &keycloakv1beta1.KeycloakClient{}
-	if err := r.Get(ctx, clientName, kcClient); err != nil {
-		return "", fmt.Errorf("failed to get KeycloakClient %s: %w", clientName, err)
-	}
-
-	if !kcClient.Status.Ready {
-		return "", fmt.Errorf("KeycloakClient %s is not ready", clientName)
-	}
-
-	if kcClient.Status.ClientUUID == "" {
-		return "", fmt.Errorf("KeycloakClient %s has no clientUUID", clientName)
-	}
-
-	return kcClient.Status.ClientUUID, nil
-}
-
 func (r *KeycloakRoleReconciler) deleteRole(ctx context.Context, role *keycloakv1beta1.KeycloakRole) error {
-	kc, realmName, err := r.getKeycloakClientAndRealm(ctx, role)
+	kc, realmName, _, err := r.getKeycloakClientAndRealm(ctx, role)
 	if err != nil {
 		return err
 	}

--- a/test/crd/crd_fields_test.go
+++ b/test/crd/crd_fields_test.go
@@ -150,6 +150,57 @@ func TestIdentifierPrinterColumnPresent(t *testing.T) {
 	}
 }
 
+// parentRefExclusivity lists CRDs whose parent references are mutually exclusive,
+// with every ref that participates in the choice. A resource that derives its
+// realm from a parent (a client role from its client) must not also accept a realm
+// ref, so the rule has to name all of them.
+var parentRefExclusivity = []struct {
+	file string
+	refs []string
+}{
+	{
+		file: "keycloak.hostzero.com_keycloakroles.yaml",
+		refs: []string{"realmRef", "clusterRealmRef", "clientRef"},
+	},
+	{
+		file: "keycloak.hostzero.com_keycloakusers.yaml",
+		refs: []string{"realmRef", "clusterRealmRef", "clientRef"},
+	},
+	{
+		file: "keycloak.hostzero.com_keycloakprotocolmappers.yaml",
+		refs: []string{"clientRef", "clientScopeRef"},
+	},
+}
+
+func TestParentRefExclusivityRule(t *testing.T) {
+	for _, exp := range parentRefExclusivity {
+		t.Run(exp.file, func(t *testing.T) {
+			crd := loadCRD(t, exp.file)
+			v := storageVersion(t, crd)
+			spec := v.Schema.OpenAPIV3Schema.Properties["spec"]
+
+			for _, ref := range exp.refs {
+				if _, ok := spec.Properties[ref]; !ok {
+					t.Errorf("%s: spec.%s not present in CRD schema", exp.file, ref)
+				}
+			}
+
+			for _, ref := range exp.refs {
+				found := false
+				for _, rule := range spec.XValidations {
+					if strings.Contains(rule.Rule, "self."+ref) && !strings.Contains(rule.Rule, "oldSelf") {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("%s: no spec-level CEL rule constrains spec.%s, so it can be combined with the other parent refs", exp.file, ref)
+				}
+			}
+		})
+	}
+}
+
 func TestIdentifierImmutabilityRule(t *testing.T) {
 	for _, exp := range expectations {
 		t.Run(exp.file, func(t *testing.T) {

--- a/test/crd/crd_fields_test.go
+++ b/test/crd/crd_fields_test.go
@@ -150,51 +150,218 @@ func TestIdentifierPrinterColumnPresent(t *testing.T) {
 	}
 }
 
-// parentRefExclusivity lists CRDs whose parent references are mutually exclusive,
-// with every ref that participates in the choice. A resource that derives its
-// realm from a parent (a client role from its client) must not also accept a realm
-// ref, so the rule has to name all of them.
-var parentRefExclusivity = []struct {
+// refContract declares, for one schema object, what every *Ref property in it is
+// for. It exists so that adding a reference to any CRD without deciding how it
+// interacts with the existing ones fails here rather than reaching users: #129
+// was a clientRef that silently required a realmRef beside it.
+type refContract struct {
 	file string
-	refs []string
-}{
+	// path locates the object inside the storage version's spec. Empty means spec
+	// itself; {"subject"} means spec.subject.
+	path []string
+	// exclusive refs participate in a "set exactly one" choice, so every one of
+	// them must be named by a CEL rule on the object.
+	exclusive []string
+	// sole refs are the object's only parent and must therefore be required.
+	sole []string
+	// data refs address something other than a parent (a Secret, typically) and
+	// carry no exclusivity obligation.
+	data []string
+}
+
+var refContracts = []refContract{
+	{file: "keycloak.hostzero.com_clusterkeycloakinstances.yaml"},
+	{file: "keycloak.hostzero.com_keycloakinstances.yaml"},
+
+	// Realms attach to an instance.
 	{
-		file: "keycloak.hostzero.com_keycloakroles.yaml",
-		refs: []string{"realmRef", "clusterRealmRef", "clientRef"},
+		file:      "keycloak.hostzero.com_keycloakrealms.yaml",
+		exclusive: []string{"instanceRef", "clusterInstanceRef"},
+		data:      []string{"smtpSecretRef"},
 	},
 	{
-		file: "keycloak.hostzero.com_keycloakusers.yaml",
-		refs: []string{"realmRef", "clusterRealmRef", "clientRef"},
+		file:      "keycloak.hostzero.com_clusterkeycloakrealms.yaml",
+		exclusive: []string{"instanceRef", "clusterInstanceRef"},
+		data:      []string{"smtpSecretRef"},
+	},
+
+	// Realm-scoped kinds with no other possible parent.
+	{
+		file:      "keycloak.hostzero.com_keycloakauthenticationflows.yaml",
+		exclusive: []string{"realmRef", "clusterRealmRef"},
 	},
 	{
-		file: "keycloak.hostzero.com_keycloakprotocolmappers.yaml",
-		refs: []string{"clientRef", "clientScopeRef"},
+		file:      "keycloak.hostzero.com_keycloakclients.yaml",
+		exclusive: []string{"realmRef", "clusterRealmRef"},
+		data:      []string{"clientSecretRef"},
+	},
+	{
+		file:      "keycloak.hostzero.com_keycloakclientscopes.yaml",
+		exclusive: []string{"realmRef", "clusterRealmRef"},
+	},
+	{
+		file:      "keycloak.hostzero.com_keycloakcomponents.yaml",
+		exclusive: []string{"realmRef", "clusterRealmRef"},
+	},
+	{
+		file:      "keycloak.hostzero.com_keycloakidentityproviders.yaml",
+		exclusive: []string{"realmRef", "clusterRealmRef"},
+		data:      []string{"configSecretRef"},
+	},
+	{
+		file:      "keycloak.hostzero.com_keycloakorganizations.yaml",
+		exclusive: []string{"realmRef", "clusterRealmRef"},
+	},
+	{
+		file:      "keycloak.hostzero.com_keycloakrequiredactions.yaml",
+		exclusive: []string{"realmRef", "clusterRealmRef"},
+	},
+
+	// Kinds whose parent can imply the realm, so the parent ref replaces the realm
+	// ref instead of accompanying it.
+	{
+		file:      "keycloak.hostzero.com_keycloakroles.yaml",
+		exclusive: []string{"realmRef", "clusterRealmRef", "clientRef"},
+	},
+	{
+		file:      "keycloak.hostzero.com_keycloakusers.yaml",
+		exclusive: []string{"realmRef", "clusterRealmRef", "clientRef"},
+	},
+	{
+		file:      "keycloak.hostzero.com_keycloakgroups.yaml",
+		exclusive: []string{"realmRef", "clusterRealmRef", "parentGroupRef"},
+	},
+
+	// Kinds that always derive the realm from a parent and so carry no realm ref.
+	{
+		file:      "keycloak.hostzero.com_keycloakprotocolmappers.yaml",
+		exclusive: []string{"clientRef", "clientScopeRef"},
+	},
+	{
+		file: "keycloak.hostzero.com_keycloakidentityprovidermappers.yaml",
+		sole: []string{"identityProviderRef"},
+	},
+	{
+		file: "keycloak.hostzero.com_keycloakusercredentials.yaml",
+		sole: []string{"userRef"},
+	},
+	{
+		file:      "keycloak.hostzero.com_keycloakrolemappings.yaml",
+		exclusive: []string{"roleRef"},
+	},
+	{
+		file:      "keycloak.hostzero.com_keycloakrolemappings.yaml",
+		path:      []string{"subject"},
+		exclusive: []string{"userRef", "groupRef", "serviceAccountRef"},
 	},
 }
 
-func TestParentRefExclusivityRule(t *testing.T) {
-	for _, exp := range parentRefExclusivity {
-		t.Run(exp.file, func(t *testing.T) {
-			crd := loadCRD(t, exp.file)
-			v := storageVersion(t, crd)
-			spec := v.Schema.OpenAPIV3Schema.Properties["spec"]
+func (c refContract) name() string {
+	if len(c.path) == 0 {
+		return c.file + " spec"
+	}
+	return c.file + " spec." + strings.Join(c.path, ".")
+}
 
-			for _, ref := range exp.refs {
-				if _, ok := spec.Properties[ref]; !ok {
-					t.Errorf("%s: spec.%s not present in CRD schema", exp.file, ref)
+// resolveObject walks path down from spec.
+func resolveObject(t *testing.T, c refContract) apiextensionsv1.JSONSchemaProps {
+	t.Helper()
+	crd := loadCRD(t, c.file)
+	v := storageVersion(t, crd)
+	obj, ok := v.Schema.OpenAPIV3Schema.Properties["spec"]
+	if !ok {
+		t.Fatalf("%s: no spec in schema", c.file)
+	}
+	for _, p := range c.path {
+		next, ok := obj.Properties[p]
+		if !ok {
+			t.Fatalf("%s: property %q not found", c.name(), p)
+		}
+		obj = next
+	}
+	return obj
+}
+
+// TestRefContractsAreComplete fails when a schema grows a *Ref property that no
+// contract accounts for, which is the drift that lets a new reference ship without
+// anyone deciding whether it replaces or accompanies the existing ones.
+func TestRefContractsAreComplete(t *testing.T) {
+	declared := map[string]map[string]bool{}
+	for _, c := range refContracts {
+		key := c.name()
+		if declared[key] == nil {
+			declared[key] = map[string]bool{}
+		}
+		for _, refs := range [][]string{c.exclusive, c.sole, c.data} {
+			for _, ref := range refs {
+				declared[key][ref] = true
+			}
+		}
+	}
+
+	for _, c := range refContracts {
+		t.Run(c.name(), func(t *testing.T) {
+			obj := resolveObject(t, c)
+			for prop := range obj.Properties {
+				if !strings.HasSuffix(prop, "Ref") {
+					continue
+				}
+				if !declared[c.name()][prop] {
+					t.Errorf("%s: %s is not declared in its refContract; classify it as exclusive, sole, or data", c.name(), prop)
 				}
 			}
+		})
+	}
+}
 
-			for _, ref := range exp.refs {
+// TestExclusiveRefsAreConstrained asserts every ref in an exclusive set is named
+// by a CEL rule, so it cannot be combined freely with its siblings.
+func TestExclusiveRefsAreConstrained(t *testing.T) {
+	for _, c := range refContracts {
+		if len(c.exclusive) == 0 {
+			continue
+		}
+		t.Run(c.name(), func(t *testing.T) {
+			obj := resolveObject(t, c)
+			for _, ref := range c.exclusive {
+				if _, ok := obj.Properties[ref]; !ok {
+					t.Errorf("%s: %s not present in schema", c.name(), ref)
+					continue
+				}
 				found := false
-				for _, rule := range spec.XValidations {
+				for _, rule := range obj.XValidations {
 					if strings.Contains(rule.Rule, "self."+ref) && !strings.Contains(rule.Rule, "oldSelf") {
 						found = true
 						break
 					}
 				}
 				if !found {
-					t.Errorf("%s: no spec-level CEL rule constrains spec.%s, so it can be combined with the other parent refs", exp.file, ref)
+					t.Errorf("%s: no CEL rule constrains %s, so it can be combined with the other refs", c.name(), ref)
+				}
+			}
+		})
+	}
+}
+
+// TestSoleRefsAreRequired asserts a lone parent ref is structurally required
+// rather than left optional with no rule to enforce it.
+func TestSoleRefsAreRequired(t *testing.T) {
+	for _, c := range refContracts {
+		if len(c.sole) == 0 {
+			continue
+		}
+		t.Run(c.name(), func(t *testing.T) {
+			obj := resolveObject(t, c)
+			for _, ref := range c.sole {
+				required := false
+				for _, r := range obj.Required {
+					if r == ref {
+						required = true
+						break
+					}
+				}
+				if !required {
+					t.Errorf("%s: %s is the only parent ref and must be listed as required", c.name(), ref)
 				}
 			}
 		})

--- a/test/e2e/group_nested_reconcile_test.go
+++ b/test/e2e/group_nested_reconcile_test.go
@@ -146,13 +146,16 @@ func newGroupCR(t *testing.T, k8sName, realmName, parentK8sName, kcGroupName str
 			Namespace: testNamespace,
 		},
 		Spec: keycloakv1beta1.KeycloakGroupSpec{
-			RealmRef:   &keycloakv1beta1.ResourceRef{Name: realmName},
 			Name:       strPtr(kcGroupName),
 			Definition: rawJSON(string(def)),
 		},
 	}
+	// A nested group inherits its realm from the parent chain, so the two refs are
+	// mutually exclusive.
 	if parentK8sName != "" {
 		g.Spec.ParentGroupRef = &keycloakv1beta1.ResourceRef{Name: parentK8sName}
+	} else {
+		g.Spec.RealmRef = &keycloakv1beta1.ResourceRef{Name: realmName}
 	}
 	return g
 }

--- a/test/e2e/group_test.go
+++ b/test/e2e/group_test.go
@@ -149,7 +149,6 @@ func TestKeycloakGroupE2E(t *testing.T) {
 				Namespace: testNamespace,
 			},
 			Spec: keycloakv1beta1.KeycloakGroupSpec{
-				RealmRef:       &keycloakv1beta1.ResourceRef{Name: realmName},
 				ParentGroupRef: &keycloakv1beta1.ResourceRef{Name: parentName},
 				Name:           strPtr(childName),
 				Definition:     childDef,
@@ -173,6 +172,82 @@ func TestKeycloakGroupE2E(t *testing.T) {
 		})
 		require.NoError(t, err, "Child group did not become ready")
 		t.Logf("Nested groups created: parent=%s, child=%s", parentName, childName)
+	})
+
+	// A nested group inherits the realm from its parent chain, so pairing
+	// parentGroupRef with a realm ref states the realm twice and is rejected.
+	t.Run("ParentGroupRefWithRealmRefRejected", func(t *testing.T) {
+		groupName := fmt.Sprintf("both-refs-group-%d", time.Now().UnixNano())
+		group := &keycloakv1beta1.KeycloakGroup{
+			ObjectMeta: metav1.ObjectMeta{Name: groupName, Namespace: testNamespace},
+			Spec: keycloakv1beta1.KeycloakGroupSpec{
+				RealmRef:       &keycloakv1beta1.ResourceRef{Name: realmName},
+				ParentGroupRef: &keycloakv1beta1.ResourceRef{Name: "some-parent"},
+				Name:           strPtr(groupName),
+				Definition:     rawJSON(`{}`),
+			},
+		}
+		err := k8sClient.Create(ctx, group)
+		require.Error(t, err, "combining realmRef and parentGroupRef must be rejected")
+		require.Contains(t, err.Error(), "exactly one of realmRef, clusterRealmRef, or parentGroupRef")
+		if err == nil {
+			t.Cleanup(func() { k8sClient.Delete(ctx, group) })
+		}
+	})
+
+	t.Run("NoParentRefRejected", func(t *testing.T) {
+		groupName := fmt.Sprintf("no-refs-group-%d", time.Now().UnixNano())
+		group := &keycloakv1beta1.KeycloakGroup{
+			ObjectMeta: metav1.ObjectMeta{Name: groupName, Namespace: testNamespace},
+			Spec: keycloakv1beta1.KeycloakGroupSpec{
+				Name:       strPtr(groupName),
+				Definition: rawJSON(`{}`),
+			},
+		}
+		err := k8sClient.Create(ctx, group)
+		require.Error(t, err, "a group without any parent ref must be rejected")
+		if err == nil {
+			t.Cleanup(func() { k8sClient.Delete(ctx, group) })
+		}
+	})
+
+	// Three levels deep: the realm for the grandchild is only reachable by walking
+	// past its parent, which itself carries no realm ref.
+	t.Run("DeeplyNestedGroupInheritsRealm", func(t *testing.T) {
+		suffix := time.Now().UnixNano()
+		names := []string{
+			fmt.Sprintf("l1-%d", suffix),
+			fmt.Sprintf("l2-%d", suffix),
+			fmt.Sprintf("l3-%d", suffix),
+		}
+
+		for i, name := range names {
+			spec := keycloakv1beta1.KeycloakGroupSpec{
+				Name:       strPtr(name),
+				Definition: rawJSON(`{}`),
+			}
+			if i == 0 {
+				spec.RealmRef = &keycloakv1beta1.ResourceRef{Name: realmName}
+			} else {
+				spec.ParentGroupRef = &keycloakv1beta1.ResourceRef{Name: names[i-1]}
+			}
+
+			group := &keycloakv1beta1.KeycloakGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
+				Spec:       spec,
+			}
+			require.NoError(t, k8sClient.Create(ctx, group))
+			t.Cleanup(func() { k8sClient.Delete(ctx, group) })
+
+			require.NoError(t, wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+				updated := &keycloakv1beta1.KeycloakGroup{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: testNamespace}, updated); err != nil {
+					return false, nil
+				}
+				return updated.Status.Ready && updated.Status.GroupID != "", nil
+			}), "group %s at nesting level %d did not become ready", name, i+1)
+		}
+		t.Logf("Three-level nesting resolved the realm through the parent chain: %v", names)
 	})
 
 	t.Run("GroupCleanup", func(t *testing.T) {

--- a/test/e2e/role_test.go
+++ b/test/e2e/role_test.go
@@ -117,7 +117,6 @@ func TestKeycloakRoleE2E(t *testing.T) {
 				Namespace: testNamespace,
 			},
 			Spec: keycloakv1beta1.KeycloakRoleSpec{
-				RealmRef:   &keycloakv1beta1.ResourceRef{Name: realmName},
 				ClientRef:  &keycloakv1beta1.ResourceRef{Name: clientName},
 				Name:       strPtr(roleName),
 				Definition: roleDef,
@@ -232,7 +231,6 @@ func TestKeycloakRoleE2E(t *testing.T) {
 			cr := &keycloakv1beta1.KeycloakRole{
 				ObjectMeta: metav1.ObjectMeta{Name: rn, Namespace: testNamespace},
 				Spec: keycloakv1beta1.KeycloakRoleSpec{
-					RealmRef:   &keycloakv1beta1.ResourceRef{Name: realmName},
 					ClientRef:  &keycloakv1beta1.ResourceRef{Name: clientName},
 					Name:       strPtr(rn),
 					Definition: rawJSON(`{}`),
@@ -359,6 +357,44 @@ func TestKeycloakRoleE2E(t *testing.T) {
 			}
 			return len(members) == 2
 		}, timeout, interval, "expected composite member set to shrink to 2 after update")
+	})
+
+	// A client role takes its realm from the client, so pairing clientRef with a
+	// realm ref states the realm twice and is rejected at admission (#129).
+	t.Run("ClientRefWithRealmRefRejected", func(t *testing.T) {
+		roleName := fmt.Sprintf("both-refs-%d", time.Now().UnixNano())
+		role := &keycloakv1beta1.KeycloakRole{
+			ObjectMeta: metav1.ObjectMeta{Name: roleName, Namespace: testNamespace},
+			Spec: keycloakv1beta1.KeycloakRoleSpec{
+				RealmRef:   &keycloakv1beta1.ResourceRef{Name: realmName},
+				ClientRef:  &keycloakv1beta1.ResourceRef{Name: "some-client"},
+				Name:       strPtr(roleName),
+				Definition: rawJSON(`{}`),
+			},
+		}
+		err := k8sClient.Create(ctx, role)
+		require.Error(t, err, "combining realmRef and clientRef must be rejected")
+		require.Contains(t, err.Error(), "exactly one of realmRef, clusterRealmRef, or clientRef")
+		if err == nil {
+			t.Cleanup(func() { k8sClient.Delete(ctx, role) })
+		}
+	})
+
+	// Every parent ref omitted is equally invalid.
+	t.Run("NoParentRefRejected", func(t *testing.T) {
+		roleName := fmt.Sprintf("no-refs-%d", time.Now().UnixNano())
+		role := &keycloakv1beta1.KeycloakRole{
+			ObjectMeta: metav1.ObjectMeta{Name: roleName, Namespace: testNamespace},
+			Spec: keycloakv1beta1.KeycloakRoleSpec{
+				Name:       strPtr(roleName),
+				Definition: rawJSON(`{}`),
+			},
+		}
+		err := k8sClient.Create(ctx, role)
+		require.Error(t, err, "a role without any parent ref must be rejected")
+		if err == nil {
+			t.Cleanup(func() { k8sClient.Delete(ctx, role) })
+		}
 	})
 
 	t.Run("RoleCleanup", func(t *testing.T) {

--- a/test/e2e/rolemapping_test.go
+++ b/test/e2e/rolemapping_test.go
@@ -725,4 +725,88 @@ func TestKeycloakClientRoleMapping(t *testing.T) {
 		require.Equal(t, "view-users", updatedMapping.Status.RoleName)
 		t.Logf("Client role mapping %s is ready, role type: %s", mappingName, updatedMapping.Status.RoleType)
 	})
+
+	// serviceAccountRef is a subject in its own right. It had no e2e coverage, which
+	// is how a CEL rule that required userRef or groupRef alongside it — making the
+	// subject unusable — went unnoticed.
+	t.Run("MapRoleToServiceAccount", func(t *testing.T) {
+		suffix := time.Now().UnixNano()
+		clientName := fmt.Sprintf("sa-subject-client-%d", suffix)
+		clientDef := rawJSON(`{
+			"enabled": true,
+			"protocol": "openid-connect",
+			"publicClient": false,
+			"serviceAccountsEnabled": true
+		}`)
+
+		kcClient := &keycloakv1beta1.KeycloakClient{
+			ObjectMeta: metav1.ObjectMeta{Name: clientName, Namespace: testNamespace},
+			Spec: keycloakv1beta1.KeycloakClientSpec{
+				RealmRef:   &keycloakv1beta1.ResourceRef{Name: realmName},
+				ClientId:   strPtr(clientName),
+				Definition: &clientDef,
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, kcClient))
+		t.Cleanup(func() { k8sClient.Delete(ctx, kcClient) })
+
+		require.NoError(t, wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+			updated := &keycloakv1beta1.KeycloakClient{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: clientName, Namespace: testNamespace}, updated); err != nil {
+				return false, nil
+			}
+			return updated.Status.Ready, nil
+		}), "KeycloakClient did not become ready")
+
+		mappingName := fmt.Sprintf("sa-role-mapping-%d", suffix)
+		realmMgmtClientId := "realm-management"
+		roleMapping := &keycloakv1beta1.KeycloakRoleMapping{
+			ObjectMeta: metav1.ObjectMeta{Name: mappingName, Namespace: testNamespace},
+			Spec: keycloakv1beta1.KeycloakRoleMappingSpec{
+				Subject: keycloakv1beta1.RoleMappingSubject{
+					ServiceAccountRef: &keycloakv1beta1.ResourceRef{Name: clientName},
+				},
+				Role: &keycloakv1beta1.RoleDefinition{
+					Name:     "view-users",
+					ClientID: &realmMgmtClientId,
+				},
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, roleMapping), "a serviceAccountRef subject must be accepted on its own")
+		t.Cleanup(func() { k8sClient.Delete(ctx, roleMapping) })
+
+		require.NoError(t, wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+			updated := &keycloakv1beta1.KeycloakRoleMapping{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: mappingName, Namespace: testNamespace}, updated); err != nil {
+				return false, nil
+			}
+			return updated.Status.Ready, nil
+		}), "service account role mapping did not become ready")
+
+		updated := &keycloakv1beta1.KeycloakRoleMapping{}
+		require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: mappingName, Namespace: testNamespace}, updated))
+		require.Equal(t, "user", updated.Status.SubjectType, "a service account resolves to a user subject")
+		require.Equal(t, "view-users", updated.Status.RoleName)
+	})
+
+	// Two subject refs at once is ambiguous.
+	t.Run("MultipleSubjectRefsRejected", func(t *testing.T) {
+		mappingName := fmt.Sprintf("two-subjects-%d", time.Now().UnixNano())
+		roleMapping := &keycloakv1beta1.KeycloakRoleMapping{
+			ObjectMeta: metav1.ObjectMeta{Name: mappingName, Namespace: testNamespace},
+			Spec: keycloakv1beta1.KeycloakRoleMappingSpec{
+				Subject: keycloakv1beta1.RoleMappingSubject{
+					UserRef:           &keycloakv1beta1.ResourceRef{Name: "some-user"},
+					ServiceAccountRef: &keycloakv1beta1.ResourceRef{Name: "some-client"},
+				},
+				RoleRef: &keycloakv1beta1.ResourceRef{Name: "some-role"},
+			},
+		}
+		err := k8sClient.Create(ctx, roleMapping)
+		require.Error(t, err, "setting two subject refs must be rejected")
+		require.Contains(t, err.Error(), "exactly one of userRef, groupRef, or serviceAccountRef")
+		if err == nil {
+			t.Cleanup(func() { k8sClient.Delete(ctx, roleMapping) })
+		}
+	})
 }

--- a/test/e2e/rolemapping_test.go
+++ b/test/e2e/rolemapping_test.go
@@ -523,7 +523,6 @@ func TestKeycloakRoleMappingRoleRefE2E(t *testing.T) {
 		role := &keycloakv1beta1.KeycloakRole{
 			ObjectMeta: metav1.ObjectMeta{Name: roleName, Namespace: testNamespace},
 			Spec: keycloakv1beta1.KeycloakRoleSpec{
-				RealmRef:   &keycloakv1beta1.ResourceRef{Name: realmName},
 				ClientRef:  &keycloakv1beta1.ResourceRef{Name: clientName},
 				Name:       strPtr(roleName),
 				Definition: rawJSON(`{}`),

--- a/test/e2e/user_roles_groups_test.go
+++ b/test/e2e/user_roles_groups_test.go
@@ -209,7 +209,6 @@ func TestKeycloakUserRolesGroupsE2E(t *testing.T) {
 			role := &keycloakv1beta1.KeycloakRole{
 				ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-role", c.crName), Namespace: testNamespace},
 				Spec: keycloakv1beta1.KeycloakRoleSpec{
-					RealmRef:   &keycloakv1beta1.ResourceRef{Name: realmName},
 					ClientRef:  &keycloakv1beta1.ResourceRef{Name: c.crName},
 					Name:       strPtr(c.role),
 					Definition: rawJSON(`{"description": "e2e client role"}`),


### PR DESCRIPTION
Closes #129.

## Why

A `KeycloakRole` for a client role needed both `clientRef` and `realmRef`, even
though the client already determines the realm. The docs described `clientRef`
alone, so the manifest in #129 was rejected at admission with a message about a
field the user had no reason to set. Nothing validated that the two refs agreed
either, so a `realmRef` naming a different realm than the client's was accepted
and then looked up the client's roles in the wrong realm.

Auditing the other CRDs turned up two more cases of the same class.

## What changed

**`KeycloakRole`** — `realmRef`, `clusterRealmRef` and `clientRef` are now
mutually exclusive, and the realm for a client role is derived from the
referenced client.

**`KeycloakGroup`** — same shape, same fix: `parentGroupRef` previously sat
beside a required realm ref. The three are now mutually exclusive and a nested
group's realm is resolved by walking `parentGroupRef` up to the ancestor that
carries it. Groups nest arbitrarily deep, so this is a walk rather than a single
hop; a reference cycle is reported as an error instead of looping.

**`KeycloakRoleMapping`** — the subject rule required `userRef` or `groupRef`,
which rejected a `serviceAccountRef` subject on its own. That subject type is
fully implemented, documented and unit tested, but unreachable through the API
server, because the unit tests call the resolver directly and there was no e2e
coverage. The rule now accepts exactly one of the three. This one is a fix, not
a break.

## Consistency

Every kind now follows one rule: a resource names exactly one parent, and if
that parent implies the realm, the realm is not named again.

| Kind | Parent refs |
|---|---|
| `KeycloakRole`, `KeycloakUser` | `realmRef` / `clusterRealmRef` / `clientRef` |
| `KeycloakGroup` | `realmRef` / `clusterRealmRef` / `parentGroupRef` |
| `KeycloakProtocolMapper` | `clientRef` / `clientScopeRef` |
| `KeycloakRoleMapping` | `userRef` / `groupRef` / `serviceAccountRef` |
| `KeycloakIdentityProviderMapper`, `KeycloakUserCredential` | single required parent |
| `KeycloakRealm`, `ClusterKeycloakRealm` | `instanceRef` / `clusterInstanceRef` |
| the seven realm-scoped kinds | `realmRef` / `clusterRealmRef` |

## Guarding against the next one

`test/crd` now checks every `*Ref` property of every CRD against a declared
contract: each ref is either part of an exclusive choice, the sole required
parent, or a data reference such as a Secret. A ref that no contract classifies
fails the build, so the next reference added to a CRD cannot ship without
someone deciding how it interacts with the existing ones. Verified non-vacuous
by removing a declaration and watching it fail.

## Breaking changes

Targeting v0.11.0.

- A `KeycloakRole` with `clientRef` must no longer set `realmRef` or `clusterRealmRef`.
- A `KeycloakGroup` with `parentGroupRef` must no longer set `realmRef` or `clusterRealmRef`.

Both were previously required, so affected manifests need the realm ref removed.

## Testing

- Unit tests, including the realm-owner walk, its cycle guard and a missing parent.
- The envtest admission suite covers all 14 reference-choice cases, among them
  `serviceAccountRef` alone being accepted and the two new group rejections.
- Converted the existing client-role and nested-group e2e cases to the parent ref
  alone, so they now prove the realm is actually derived.
- Added e2e cases for three-level group nesting, the rejected combinations, and a
  role mapping onto a client's service account.
- Full e2e suite against Keycloak in Kind: 221 subtests pass, no failures.